### PR TITLE
Add bloque de resumen de OTs al dashboard principal

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -46,6 +46,12 @@ class DashboardController extends Controller
         
         // Calcular el total de ordenes del día
         $totalOrdenes = count($ordenesHoy);
+
+        // Últimas 5 ordenes (de cualquier fecha, ordenados por creación)
+        $ultimasOrdenes = OrdenDeTrabajo::orderBy('updated_at', 'desc')
+            ->withSum('detalles', 'valor')
+            ->limit(5)
+            ->get();
         
         // Balance del día (ingresos - egresos)
         $balanceDelDia = $totalIngresos - $totalEgresos;
@@ -55,6 +61,7 @@ class DashboardController extends Controller
             'totalIngresos' => (float) $totalIngresos,
             'totalOrdenes' => $totalOrdenes,
             'balanceDelDia' => (float) $balanceDelDia,
+            'ultimasOrdenes' => $ultimasOrdenes
         ];
 
         // Renderizar vista según el rol del usuario
@@ -63,7 +70,8 @@ class DashboardController extends Controller
             return Inertia::render('Administrador/inicio', [
                 'stats' => $stats,
                 'ultimosEgresos' => $ultimosEgresos,
-                'ultimosIngresos' => $ultimosIngresos
+                'ultimosIngresos' => $ultimosIngresos,
+                'ultimasOrdenes' => $ultimasOrdenes
             ]);
         }
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -48,11 +48,15 @@ class DashboardController extends Controller
         $totalOrdenes = count($ordenesHoy);
 
         // Últimas 5 ordenes (de cualquier fecha, ordenados por creación)
-        $ultimasOrdenes = OrdenDeTrabajo::orderBy('updated_at', 'desc')
+        $ultimasOrdenes = OrdenDeTrabajo::with([
+                'titularVehiculo.vehiculo.marca',
+                'titularVehiculo.vehiculo.modelo'
+            ])
+            ->orderBy('updated_at', 'desc')
             ->withSum('detalles', 'valor')
             ->limit(5)
             ->get();
-        
+        //dd($ultimasOrdenes);
         // Balance del día (ingresos - egresos)
         $balanceDelDia = $totalIngresos - $totalEgresos;
 

--- a/app/Models/Movimiento.php
+++ b/app/Models/Movimiento.php
@@ -23,7 +23,6 @@ class Movimiento extends Model
         'monto',
         'concepto_id',
         'medio_de_pago_id',
-        'comprobante',
         'tipo',
     ];
 

--- a/app/Models/OrdenDeTrabajo.php
+++ b/app/Models/OrdenDeTrabajo.php
@@ -43,15 +43,15 @@ class OrdenDeTrabajo extends Model
         return $this->hasMany(DetalleOrdenDeTrabajo::class, 'orden_de_trabajo_id');
     }
 
-public function companiaSeguro()
-{
-    return $this->belongsTo(\App\Models\CompaniaSeguro::class, 'compania_seguro_id')
-        ->withTrashed();
-}
+    public function companiaSeguro()
+    {
+        return $this->belongsTo(\App\Models\CompaniaSeguro::class, 'compania_seguro_id')
+            ->withTrashed();
+    }
 
-public function pagos()
-{
-    return $this->hasMany(\App\Models\Precio::class, 'orden_de_trabajo_id');
-}
+    public function pagos()
+    {
+        return $this->hasMany(\App\Models\Precio::class, 'orden_de_trabajo_id');
+    }
 
 }

--- a/resources/js/pages/Administrador/inicio.tsx
+++ b/resources/js/pages/Administrador/inicio.tsx
@@ -9,6 +9,16 @@ interface Movimiento {
     medioDePago?: { nombre: string };
 }
 
+interface OrdenDeTrabajo {
+    id: number;
+    numero_orden: string;
+    monto: number;
+    created_at: string;
+    concepto?: { nombre: string };
+    medioDePago?: { nombre: string };
+    detalles_sum_valor: number; // Suma de los montos de los detalles de la orden
+}
+
 interface DashboardStats {
     totalEgresos: number;
     totalIngresos: number;
@@ -20,9 +30,10 @@ interface Props {
     stats: DashboardStats;
     ultimosEgresos: Movimiento[];
     ultimosIngresos: Movimiento[];
+    ultimasOrdenes: OrdenDeTrabajo[];
 }
 
-export default function AdminDashboard({ stats, ultimosEgresos, ultimosIngresos }: Props) {
+export default function AdminDashboard({ stats, ultimosEgresos, ultimosIngresos, ultimasOrdenes }: Props) {
     const formatMoney = (amount: number) => {
         return new Intl.NumberFormat('es-AR', {
             style: 'currency',
@@ -280,21 +291,59 @@ export default function AdminDashboard({ stats, ultimosEgresos, ultimosIngresos 
                             </Link>
                         </div>
                         <div className="space-y-3">
-                            <div className="py-8 text-center">
-                                <div className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-purple-100">
-                                    <svg className="h-8 w-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            strokeWidth={2}
-                                            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-                                        />
-                                    </svg>
+                            {ultimasOrdenes && ultimasOrdenes.length > 0 ? (
+                                <>
+                                    {ultimasOrdenes.map((orden) => (
+                                        <div
+                                            key={orden.id}
+                                            className="flex items-center justify-between border-b border-gray-100 py-3 last:border-0"
+                                        >
+                                            <div className="flex-1">
+                                                <p className="font-semibold text-gray-900">{orden.numero_orden || 'Sin número de orden'}</p>
+                                                <p className="text-sm text-gray-500">
+                                                    {formatTimeAgo(orden.created_at)}
+                                                    {orden.medioDePago && <span className="ml-2">• {orden.numero_orden}</span>}
+                                                </p>
+                                            </div>
+                                            <span className="ml-4 font-bold text-red-600">{formatMoney(orden.detalles_sum_valor)}</span>
+                                        </div>
+                                    ))}
+                                    <Link
+                                        href="/ordenes/create"
+                                        className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg bg-red-50 py-3 font-semibold text-red-600 transition hover:bg-red-100"
+                                    >
+                                        <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                                        </svg>
+                                        Registrar nueva orden
+                                    </Link>
+                                </>
+                            ) : (
+                                <div className="py-8 text-center">
+                                    <div className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
+                                        <svg className="h-8 w-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                strokeWidth={2}
+                                                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                                            />
+                                        </svg>
+                                    </div>
+                                    <p className="mb-3 font-medium text-gray-500">No hay órdenes registradas</p>
+                                    <Link
+                                        href="/ordenes/create"
+                                        className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 font-semibold text-white transition hover:bg-red-700"
+                                    >
+                                        <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                                        </svg>
+                                        Registrar la primera
+                                    </Link>
                                 </div>
-                                <p className="mb-2 font-medium text-gray-500">Sección en desarrollo</p>
-                                <p className="text-sm text-gray-400">Las órdenes de trabajo estarán disponibles pronto</p>
-                            </div>
+                            )}
                         </div>
+                    
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/Administrador/inicio.tsx
+++ b/resources/js/pages/Administrador/inicio.tsx
@@ -17,6 +17,18 @@ interface OrdenDeTrabajo {
     concepto?: { nombre: string };
     medioDePago?: { nombre: string };
     detalles_sum_valor: number; // Suma de los montos de los detalles de la orden
+
+    titular_vehiculo?: {
+        vehiculo?: {
+            patente: string;
+            marca?: {
+                nombre: string;
+            };
+            modelo?: {
+                nombre: string;
+            };
+        };
+    };
 }
 
 interface DashboardStats {
@@ -72,11 +84,10 @@ export default function AdminDashboard({ stats, ultimosEgresos, ultimosIngresos,
                 <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
                     {/* Balance del día */}
                     <div
-                        className={`rounded-2xl p-6 text-white shadow-lg ${
-                            stats.balanceDelDia >= 0
+                        className={`rounded-2xl p-6 text-white shadow-lg ${stats.balanceDelDia >= 0
                                 ? 'bg-gradient-to-br from-blue-500 to-blue-600'
                                 : 'bg-gradient-to-br from-orange-500 to-orange-600'
-                        }`}
+                            }`}
                     >
                         <div className="mb-4 flex items-center justify-between">
                             <h3 className="text-sm font-semibold opacity-90">Balance del Día</h3>
@@ -299,18 +310,22 @@ export default function AdminDashboard({ stats, ultimosEgresos, ultimosIngresos,
                                             className="flex items-center justify-between border-b border-gray-100 py-3 last:border-0"
                                         >
                                             <div className="flex-1">
-                                                <p className="font-semibold text-gray-900">{orden.numero_orden || 'Sin número de orden'}</p>
+                                                <a href={`/ordenes/${orden.id}`}>
+                                                    <p className="font-semibold text-gray-900">{ orden.titular_vehiculo?.vehiculo?.marca?.nombre}{" "}
+                                                        {orden.titular_vehiculo?.vehiculo?.modelo?.nombre}{" - "}
+                                                        {orden.titular_vehiculo?.vehiculo?.patente}</p>
                                                 <p className="text-sm text-gray-500">
                                                     {formatTimeAgo(orden.created_at)}
                                                     {orden.medioDePago && <span className="ml-2">• {orden.numero_orden}</span>}
                                                 </p>
+                                            </a>
                                             </div>
-                                            <span className="ml-4 font-bold text-red-600">{formatMoney(orden.detalles_sum_valor)}</span>
+                                            <span className="ml-4 font-bold text-purple-600">{formatMoney(orden.detalles_sum_valor)}</span>
                                         </div>
                                     ))}
                                     <Link
                                         href="/ordenes/create"
-                                        className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg bg-red-50 py-3 font-semibold text-red-600 transition hover:bg-red-100"
+                                        className="mt-4 flex w-full items-center justify-center gap-2 rounded-lg bg-purple-50 py-3 font-semibold text-purple-600 transition hover:bg-purple-100"
                                     >
                                         <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
@@ -333,7 +348,7 @@ export default function AdminDashboard({ stats, ultimosEgresos, ultimosIngresos,
                                     <p className="mb-3 font-medium text-gray-500">No hay órdenes registradas</p>
                                     <Link
                                         href="/ordenes/create"
-                                        className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 font-semibold text-white transition hover:bg-red-700"
+                                        className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-5 py-2.5 font-semibold text-white transition hover:bg-purple-700"
                                     >
                                         <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
@@ -343,7 +358,7 @@ export default function AdminDashboard({ stats, ultimosEgresos, ultimosIngresos,
                                 </div>
                             )}
                         </div>
-                    
+
                     </div>
                 </div>
             </div>

--- a/resources/js/pages/movimientos/create.tsx
+++ b/resources/js/pages/movimientos/create.tsx
@@ -48,7 +48,6 @@ export default function Create({ conceptos, mediosDePago, tipo, label }: Props) 
         monto: '',
         concepto_id: '',
         medio_de_pago_id: '',
-        comprobante: '',
         comprobantes: [] as File[],
 
     });
@@ -196,30 +195,6 @@ export default function Create({ conceptos, mediosDePago, tipo, label }: Props) 
                                     </p>
                                 )}
                             </div>
-                        </div>
-
-                        {/* Comprobante */}
-                        <div>
-                            <label htmlFor="comprobante" className="block text-sm font-semibold text-gray-800 mb-2">
-                                Número de Comprobante
-                            </label>
-                            <input
-                                id="comprobante"
-                                type="text"
-                                placeholder="Ej: 001-00123456"
-                                value={data.comprobante}
-                                onChange={(e) => setData('comprobante', e.target.value)}
-                                className={`w-full px-4 py-3 bg-gray-50 border-2 rounded-xl focus:ring-2 ${current.ring500} ${current.border500} focus:bg-white outline-none transition text-gray-900 font-medium placeholder:text-gray-400 ${errors.comprobante ? 'border-red-500 bg-red-50' : 'border-gray-200 hover:border-gray-300'
-                                    }`}
-                            />
-                            {errors.comprobante && (
-                                <p className="mt-2 text-sm text-red-600 flex items-center gap-1">
-                                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
-                                    </svg>
-                                    {errors.comprobante}
-                                </p>
-                            )}
                         </div>
 
                         {/* Comprobantes */}

--- a/resources/js/types/movimiento.ts
+++ b/resources/js/types/movimiento.ts
@@ -28,6 +28,5 @@ export interface MovimientoFormData {
     monto: string | number;
     concepto_id: string | number;
     medio_de_pago_id: string | number;
-    comprobante: string;
     comprobantes: File[];
 }


### PR DESCRIPTION
- Agrego funcionalidad al bloque de resumen de las últimas 5 órdenes de trabajo en el dashboard principal.
- Elimino el número de comprobante de los movimientos, tanto de los ingresos como de los egresos.