### PR TITLE
Anulación de OTs + Modulo de Conceptos + mejoras varias

### DIFF
--- a/app/Http/Controllers/ConceptoController.php
+++ b/app/Http/Controllers/ConceptoController.php
@@ -70,6 +70,10 @@ class ConceptoController extends Controller
      */
     public function update(Request $request, Concepto $concepto)
     {
+        if ($concepto->sistema) {
+            return redirect()->back()->with('error', 'Este concepto es del sistema y no puede modificarse.');
+        }
+
         $validated = $request->validate([
             'nombre' => 'required|string|max:50|unique:concepto,nombre,' . $concepto->id,
             'tipo' => 'required|in:ingreso,egreso',
@@ -91,6 +95,10 @@ class ConceptoController extends Controller
      */
     public function destroy(Concepto $concepto)
     {
+        if ($concepto->sistema) {
+            return redirect()->back()->with('error', 'Este concepto es del sistema y no puede eliminarse.');
+        }
+
         // Verificar si tiene movimientos asociados
         if ($concepto->movimientos()->exists()) {
             return redirect()->back()->with('error', 'No se puede eliminar: el concepto tiene movimientos asociados.');

--- a/app/Http/Controllers/ConceptoController.php
+++ b/app/Http/Controllers/ConceptoController.php
@@ -33,7 +33,7 @@ class ConceptoController extends Controller
         $totalIngresos = Concepto::where('tipo', 'ingreso')->count();
         $totalEgresos = Concepto::where('tipo', 'egreso')->count();
 
-        return Inertia::render('Conceptos/Index', [
+        return Inertia::render('conceptos/index', [
             'conceptos' => $conceptos,
             'filters' => $request->only(['search', 'tipo']),
             'stats' => [

--- a/app/Http/Controllers/MetricsController.php
+++ b/app/Http/Controllers/MetricsController.php
@@ -134,6 +134,7 @@ class MetricsController extends Controller
     {
         $otCreadas = (int) OrdenDeTrabajo::query()
             ->whereBetween('fecha', [$from, $to])
+            ->whereHas('estado', fn($q) => $q->where('nombre', '!=', 'Anulada'))
             ->count();
 
         $otCompletadas = (int) OrdenDeTrabajo::query()

--- a/app/Http/Controllers/OrdenDeTrabajoController.php
+++ b/app/Http/Controllers/OrdenDeTrabajoController.php
@@ -206,10 +206,10 @@ class OrdenDeTrabajoController extends Controller
             return $acc + (floatval($detalle['valor']) * intval($detalle['cantidad']));
         }, 0);
 
-    // --- NUEVA VALIDACIÓN PARA CREACIÓN ---
+        // --- NUEVA VALIDACIÓN PARA CREACIÓN ---
         $estadoFinalizada = Estado::where('nombre', 'Finalizada')->first();
 
-        if ($estadoFinalizada && (int)$validated['estado_id'] === $estadoFinalizada->id) {
+        if ($estadoFinalizada && (int) $validated['estado_id'] === $estadoFinalizada->id) {
             // Sumamos los montos de los pagos que se están enviando como "pagado"
             $totalPagado = collect($validated['pagos'])
                 ->where('pagado', true)
@@ -218,7 +218,7 @@ class OrdenDeTrabajoController extends Controller
             if ($totalPagado < $totalOrden) {
                 $falta = $totalOrden - $totalPagado;
                 return back()
-                    ->withErrors(['estado_id' => "No puedes crear una orden 'Finalizada' si no está totalmente pagada. Saldo pendiente: $".number_format($falta, 2)])
+                    ->withErrors(['estado_id' => "No puedes crear una orden 'Finalizada' si no está totalmente pagada. Saldo pendiente: $" . number_format($falta, 2)])
                     ->withInput();
             }
         }
@@ -396,26 +396,26 @@ class OrdenDeTrabajoController extends Controller
             return $acc + (floatval($detalle['valor']) * intval($detalle['cantidad']));
         }, 0);
 
-// --- NUEVA VALIDACIÓN DE ESTADO FINALIZADA ---
-            $estadoFinalizada = Estado::where('nombre', 'Finalizada')->first();
-            
-            if ($estadoFinalizada && (int)$validated['estado_id'] === $estadoFinalizada->id) {
-                // Calculamos lo que ya está pagado (incluyendo los que se están enviando ahora como pagados)
-                $totalPagado = collect($validated['pagos'])
-                    ->where('pagado', true)
-                    ->sum('monto');
+        // --- NUEVA VALIDACIÓN DE ESTADO FINALIZADA ---
+        $estadoFinalizada = Estado::where('nombre', 'Finalizada')->first();
 
-                if ($totalPagado < $totalOrden) {
-                    $falta = $totalOrden - $totalPagado;
-                    return back()
-                        ->withErrors(['estado_id' => "No se puede finalizar la OT: El saldo pendiente es de $".number_format($falta, 2)])
-                        ->withInput();
-                }
+        if ($estadoFinalizada && (int) $validated['estado_id'] === $estadoFinalizada->id) {
+            // Calculamos lo que ya está pagado (incluyendo los que se están enviando ahora como pagados)
+            $totalPagado = collect($validated['pagos'])
+                ->where('pagado', true)
+                ->sum('monto');
+
+            if ($totalPagado < $totalOrden) {
+                $falta = $totalOrden - $totalPagado;
+                return back()
+                    ->withErrors(['estado_id' => "No se puede finalizar la OT: El saldo pendiente es de $" . number_format($falta, 2)])
+                    ->withInput();
             }
-            // --- FIN DE VALIDACIÓN ---
+        }
+        // --- FIN DE VALIDACIÓN ---
 
-            if ($totalOrden <= 0) {
-        // ... (resto del código)
+        if ($totalOrden <= 0) {
+            // ... (resto del código)
             return back()
                 ->withErrors(['detalles' => 'El total de la orden debe ser mayor a $0.'])
                 ->withInput();
@@ -578,9 +578,9 @@ class OrdenDeTrabajoController extends Controller
             foreach ($pagos as $pago) {
                 // Solo procesar pagos bloqueados que NO tengan movimiento registrado
                 if ($pago->bloqueado && !$pago->movimiento_registrado) {
-                    
+
                     $monto = (float) $pago->valor;
-                    
+
                     // Determinar tipo y concepto según el signo del monto
                     if ($monto >= 0) {
                         $tipo = Movimiento::TIPO_INGRESO;
@@ -591,7 +591,7 @@ class OrdenDeTrabajoController extends Controller
                         $montoParaGuardar = abs($monto);
                         $conceptoId = 7; // Ajuste de cobro
                     }
-                    
+
                     // Crear el movimiento
                     Movimiento::create([
                         'fecha' => $pago->fecha ?? $orden->fecha,
@@ -602,10 +602,10 @@ class OrdenDeTrabajoController extends Controller
                         'tipo' => $tipo,
                         'orden_de_trabajo_id' => $orden->id,
                     ]);
-                    
+
                     // Marcar como registrado
                     $pago->update(['movimiento_registrado' => true]);
-                    
+
                     Log::info("Movimiento de {$tipo} creado para pago ID {$pago->id} de OT #{$orden->id} - Monto: {$monto}");
                 }
             }
@@ -694,5 +694,57 @@ class OrdenDeTrabajoController extends Controller
             'estados' => $estados,
             'mediosDePago' => $mediosDePago,
         ]);
+    }
+
+    public function destroy(OrdenDeTrabajo $orden)
+    {
+        $estadoAnulada = Estado::where('nombre', 'Anulada')->first();
+
+        if (!$estadoAnulada) {
+            return back()->withErrors(['error' => 'No se encontró el estado "Anulada" en el sistema.']);
+        }
+
+        if ((int) $orden->estado_id === $estadoAnulada->id) {
+            return back()->withErrors(['error' => 'Esta orden ya fue anulada.']);
+        }
+
+        DB::transaction(function () use ($orden, $estadoAnulada) {
+            // 1) Buscar movimientos de ingreso vinculados a esta OT
+            $ingresosExistentes = Movimiento::where('orden_de_trabajo_id', $orden->id)
+                ->where('tipo', Movimiento::TIPO_INGRESO)
+                ->get();
+
+            // 2) Si existen ingresos, generar egresos de reversa
+            if ($ingresosExistentes->isNotEmpty()) {
+                $conceptoAnulacion = Concepto::where('nombre', 'Anulación OT')->first();
+
+                foreach ($ingresosExistentes as $ingreso) {
+                    Movimiento::create([
+                        'fecha' => now()->toDateString(),
+                        'monto' => $ingreso->monto,
+                        'concepto_id' => $conceptoAnulacion->id,
+                        'medio_de_pago_id' => $ingreso->medio_de_pago_id,
+                        'tipo' => Movimiento::TIPO_EGRESO,
+                        'orden_de_trabajo_id' => $orden->id,
+                    ]);
+                }
+
+                Log::info("Movimientos de reversa generados para OT #{$orden->id}: {$ingresosExistentes->count()} egresos.");
+            }
+
+            // 3) Cambiar estado a "Anulada"
+            $orden->update(['estado_id' => $estadoAnulada->id]);
+
+            // 4) Registrar en historial de estados
+            OrdenDeTrabajoHistorialEstado::create([
+                'orden_de_trabajo_id' => $orden->id,
+                'estado_id' => $estadoAnulada->id,
+                'user_id' => auth()->id(),
+            ]);
+        });
+
+        return redirect()
+            ->route('ordenes.index')
+            ->with('success', "Orden #{$orden->id} anulada correctamente ✅");
     }
 }

--- a/app/Http/Controllers/OrdenDeTrabajoController.php
+++ b/app/Http/Controllers/OrdenDeTrabajoController.php
@@ -231,6 +231,29 @@ class OrdenDeTrabajoController extends Controller
                 ->withInput();
         }
 
+        // --- VALIDACIÓN DE ATRIBUTOS OBLIGATORIOS ---
+        $atributoFieldErrors = [];
+        $faltantesPorArticulo = [];
+        foreach ($validated['detalles'] as $idx => $detalle) {
+            $art = Articulo::with('categorias')->find($detalle['articulo_id']);
+            if ($art) {
+                foreach ($art->categorias as $cat) {
+                    if ($cat->obligatoria && empty($detalle['atributos'][$cat->id] ?? null)) {
+                        $atributoFieldErrors["detalles.{$idx}.atributos.{$cat->id}"] = ' ';
+                        $faltantesPorArticulo[$art->nombre][] = $cat->nombre;
+                    }
+                }
+            }
+        }
+        if (!empty($atributoFieldErrors)) {
+            $partes = [];
+            foreach ($faltantesPorArticulo as $artNombre => $campos) {
+                $partes[] = 'Falta completar ' . implode(' y ', $campos) . ' del artículo ' . $artNombre;
+            }
+            return back()->withErrors($atributoFieldErrors)->withInput()->with('error', implode('. ', $partes) . '.');
+        }
+        // --- FIN VALIDACIÓN ---
+
         $data = $request->all();
 
         $faltanDatos =
@@ -481,6 +504,29 @@ class OrdenDeTrabajoController extends Controller
                     'user_id' => auth()->id()
                 ]);
             }
+
+            // --- VALIDACIÓN DE ATRIBUTOS OBLIGATORIOS ---
+            $atributoFieldErrors = [];
+            $faltantesPorArticulo = [];
+            foreach ($validated['detalles'] as $idx => $detalle) {
+                $art = Articulo::with('categorias')->find($detalle['articulo_id']);
+                if ($art) {
+                    foreach ($art->categorias as $cat) {
+                        if ($cat->obligatoria && empty($detalle['atributos'][$cat->id] ?? null)) {
+                            $atributoFieldErrors["detalles.{$idx}.atributos.{$cat->id}"] = ' ';
+                            $faltantesPorArticulo[$art->nombre][] = $cat->nombre;
+                        }
+                    }
+                }
+            }
+            if (!empty($atributoFieldErrors)) {
+                $partes = [];
+                foreach ($faltantesPorArticulo as $artNombre => $campos) {
+                    $partes[] = 'Falta completar ' . implode(' y ', $campos) . ' del artículo ' . $artNombre;
+                }
+                return back()->withErrors($atributoFieldErrors)->withInput()->with('error', implode('. ', $partes) . '.');
+            }
+            // --- FIN VALIDACIÓN ---
 
             foreach ($orden->detalles as $det) {
                 if (method_exists($det, 'atributos')) {

--- a/app/Http/Controllers/OrdenDeTrabajoController.php
+++ b/app/Http/Controllers/OrdenDeTrabajoController.php
@@ -66,6 +66,7 @@ class OrdenDeTrabajoController extends Controller
                 fn($q) => $q->whereDate('fecha', '<=', $request->date_to)
             )
             ->orderByDesc('fecha')
+            ->orderByDesc('orden_de_trabajo.id')
             ->paginate($perPage)
             ->withQueryString();
 

--- a/database/migrations/2026_03_29_180241_add_estado_anulada_and_concepto_anulacion_ot.php
+++ b/database/migrations/2026_03_29_180241_add_estado_anulada_and_concepto_anulacion_ot.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // Agregar estado "Anulada"
+        DB::table('estado')->insert([
+            'nombre' => 'Anulada',
+        ]);
+
+        // Agregar concepto "Anulación OT" para movimientos de reversa
+        DB::table('concepto')->insert([
+            'nombre' => 'Anulación OT',
+            'tipo' => 'egreso',
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('estado')->where('nombre', 'Anulada')->delete();
+        DB::table('concepto')->where('nombre', 'Anulación OT')->delete();
+    }
+};

--- a/database/migrations/2026_03_29_192039_add_sistema_to_concepto_table.php
+++ b/database/migrations/2026_03_29_192039_add_sistema_to_concepto_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('concepto', function (Blueprint $table) {
+            $table->boolean('sistema')->default(false)->after('tipo');
+        });
+
+        // Marcar conceptos del sistema como no editables
+        DB::table('concepto')
+            ->whereIn('nombre', ['Anulación OT'])
+            ->update(['sistema' => true]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('concepto', function (Blueprint $table) {
+            $table->dropColumn('sistema');
+        });
+    }
+};

--- a/resources/js/components/ConfirmAnularModal.tsx
+++ b/resources/js/components/ConfirmAnularModal.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+} from "@/components/ui/dialog";
+import { Ban, AlertTriangle } from "lucide-react";
+
+type Props = {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    ordenId: number;
+};
+
+export default function ConfirmAnularModal({ open, onClose, onConfirm, ordenId }: Props) {
+    return (
+        <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <div className="mx-auto mb-2 flex h-14 w-14 items-center justify-center rounded-full bg-red-100">
+                        <AlertTriangle className="h-7 w-7 text-red-600" />
+                    </div>
+                    <DialogTitle className="text-center text-xl">
+                        ¿Anular Orden #{ordenId}?
+                    </DialogTitle>
+                    <DialogDescription className="text-center text-gray-600 mt-2">
+                        Esta acción no se puede deshacer. Si la orden ya generó ingresos en caja,
+                        se crearán <strong className="text-gray-900">movimientos de reversa</strong> (egresos)
+                        para compensar automáticamente.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <DialogFooter className="mt-4 flex gap-3 sm:justify-center">
+                    <button
+                        onClick={onClose}
+                        className="flex-1 rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+                    >
+                        Cancelar
+                    </button>
+                    <button
+                        onClick={onConfirm}
+                        className="flex-1 inline-flex items-center justify-center gap-2 rounded-xl bg-red-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-red-700 shadow-md"
+                    >
+                        <Ban className="w-4 h-4" />
+                        Sí, anular
+                    </button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/resources/js/components/ui/DetallesSection.tsx
+++ b/resources/js/components/ui/DetallesSection.tsx
@@ -10,6 +10,7 @@ export interface SubcategoriaDTO {
 export interface CategoriaDTO {
   id: number;
   nombre: string;
+  obligatoria: boolean;
   subcategorias: SubcategoriaDTO[];
 }
 
@@ -152,13 +153,18 @@ export default function DetallesSection({ detalles, setDetalles, articulos, erro
         {detalles.map((detalle, index) => {
           const articulo = detalle.articulo_id ? articulosById.get(detalle.articulo_id) : undefined;
           const isItemConfigured = detalle.articulo_id !== null;
+          const hasAtributoErrors = articulo?.categorias?.some(
+            (cat) => cat.obligatoria && getItemError(index, `atributos.${cat.id}`)
+          );
 
           return (
             <div
               key={index}
-              className={`rounded-xl border-2 p-4 transition-all ${isItemConfigured
-                ? 'border-green-300 bg-green-50/30'
-                : 'border-gray-200 bg-white'
+              className={`rounded-xl border-2 p-4 transition-all ${hasAtributoErrors
+                ? 'border-red-400 bg-red-50/30'
+                : isItemConfigured
+                  ? 'border-green-300 bg-green-50/30'
+                  : 'border-gray-200 bg-white'
                 }`}
             >
               {/* Fila principal compacta */}
@@ -278,10 +284,11 @@ export default function DetallesSection({ detalles, setDetalles, articulos, erro
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
                     {articulo.categorias.map((cat) => {
                       const selected = detalle.atributos?.[cat.id] ?? null;
+                      const hasError = getItemError(index, `atributos.${cat.id}`);
                       return (
                         <div key={cat.id}>
                           <label className="block text-xs text-gray-500 mb-1">
-                            {cat.nombre}
+                            {cat.nombre}{cat.obligatoria && <span className="text-red-500 ml-0.5">*</span>}
                           </label>
                           <select
                             value={selected ?? ""}
@@ -292,7 +299,8 @@ export default function DetallesSection({ detalles, setDetalles, articulos, erro
                                 e.target.value ? Number(e.target.value) : null
                               )
                             }
-                            className="w-full px-2 py-1.5 text-sm bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500 outline-none transition"
+                            className={`w-full px-2 py-1.5 text-sm bg-white border rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500 outline-none transition ${hasError ? 'border-red-500 bg-red-50' : 'border-gray-300'
+                              }`}
                           >
                             <option value="">Seleccionar...</option>
                             {cat.subcategorias.map((sc) => (

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -75,7 +75,7 @@ export default function DashboardLayout({ children, title }: Props) {
             />
 
             {/* 🔹 NAVBAR */}
-            <nav className="border-b border-gray-200 bg-white shadow-sm">
+            <nav className="relative z-50 border-b border-gray-200 bg-white shadow-sm">
                 <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
                     <div className="flex h-16 items-center justify-between">
                         {/* Logo + nombre */}
@@ -100,47 +100,42 @@ export default function DashboardLayout({ children, title }: Props) {
                             <div className="flex items-center gap-2">
                                 <Link
                                     href="/admin"
-                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/admin') && !isActive('/admin/users')
+                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/admin') && !isActive('/admin/users')
                                             ? 'bg-blue-50 text-blue-700 shadow-sm'
                                             : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                        }`}
                                 >
                                     📊 Panel de Control
                                 </Link>
 
                                 <Link
                                     href="/egresos"
-                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/egresos') ? 'bg-red-50 text-red-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/egresos') ? 'bg-red-50 text-red-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
+                                        }`}
                                 >
                                     💸 Egresos
                                 </Link>
 
                                 <Link
                                     href="/ingresos"
-                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/ingresos') ? 'bg-green-50 text-green-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/ingresos') ? 'bg-green-50 text-green-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
+                                        }`}
                                 >
                                     💰 Ingresos
                                 </Link>
 
                                 <Link
                                     href="/resumen-del-dia"
-                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/resumen-del-dia') ? 'bg-blue-50 text-blue-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/resumen-del-dia') ? 'bg-blue-50 text-blue-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
+                                        }`}
                                 >
                                     🧾 Resumen del día
                                 </Link>
 
                                 <Link
                                     href="/ordenes"
-                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/ordenes') ? 'bg-purple-50 text-purple-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                    className={`rounded-lg px-4 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/ordenes') ? 'bg-purple-50 text-purple-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
+                                        }`}
                                 >
                                     🚗 Órdenes de Trabajo
                                 </Link>
@@ -167,33 +162,29 @@ export default function DashboardLayout({ children, title }: Props) {
                                         <div className="absolute top-full right-0 z-50 mt-1 w-48 rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
                                             <Link
                                                 href="/clientes"
-                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                    isActive('/clientes') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                }`}
+                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/clientes') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                    }`}
                                             >
                                                 👥 Clientes
                                             </Link>
                                             <Link
                                                 href="/catalogo-vehiculos"
-                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                    isActive('/catalogo-vehiculos') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                }`}
+                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/catalogo-vehiculos') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                    }`}
                                             >
                                                 🚙 Vehículos
                                             </Link>
                                             <Link
                                                 href="/companias-seguros"
-                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                    isActive('/companias-seguros') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                }`}
+                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/companias-seguros') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                    }`}
                                             >
                                                 🛡️ Seguros
                                             </Link>
                                             <Link
                                                 href="/articulos"
-                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                    isActive('/articulos') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                }`}
+                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/articulos') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                    }`}
                                             >
                                                 📦 Artículos
                                             </Link>
@@ -202,35 +193,31 @@ export default function DashboardLayout({ children, title }: Props) {
                                             </Link>
                                             <Link
                                                 href="/medio-de-pago"
-                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                    isActive('/medio-de-pago') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                }`}
+                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/medio-de-pago') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                    }`}
                                             >
                                                 💳 Medios de pago
                                             </Link>
                                             {/* 🏷️ CONCEPTOS */}
                                             <Link
                                                 href="/conceptos"
-                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                    isActive('/conceptos') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                }`}
+                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/conceptos') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                    }`}
                                             >
                                                 🏷️ Conceptos
                                             </Link>
                                             <Link
                                                 href="/admin/metrics"
-                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                    isActive('/admin/metrics') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                }`}
+                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/admin/metrics') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                    }`}
                                             >
                                                 📈 Métricas
                                             </Link>
                                             <div className="my-1 border-t border-gray-100"></div>
                                             <Link
                                                 href="/admin/users"
-                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                    isActive('/admin/users') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                }`}
+                                                className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/admin/users') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                    }`}
                                             >
                                                 👤 Usuarios
                                             </Link>
@@ -255,38 +242,34 @@ export default function DashboardLayout({ children, title }: Props) {
                             <div className="flex items-center gap-2">
                                 <Link
                                     href="/admin"
-                                    className={`rounded-lg px-3 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/admin') && !isActive('/admin/users')
+                                    className={`rounded-lg px-3 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/admin') && !isActive('/admin/users')
                                             ? 'bg-blue-50 text-blue-700 shadow-sm'
                                             : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                        }`}
                                 >
                                     📊 Panel de Control
                                 </Link>
 
                                 <Link
                                     href="/egresos"
-                                    className={`rounded-lg px-3 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/egresos') ? 'bg-red-50 text-red-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                    className={`rounded-lg px-3 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/egresos') ? 'bg-red-50 text-red-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
+                                        }`}
                                 >
                                     💸 Egresos
                                 </Link>
 
                                 <Link
                                     href="/ingresos"
-                                    className={`rounded-lg px-3 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/ingresos') ? 'bg-green-50 text-green-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                    className={`rounded-lg px-3 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/ingresos') ? 'bg-green-50 text-green-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
+                                        }`}
                                 >
                                     💰 Ingresos
                                 </Link>
 
                                 <Link
                                     href="/ordenes"
-                                    className={`rounded-lg px-3 py-2 text-sm font-semibold whitespace-nowrap transition-all ${
-                                        isActive('/ordenes') ? 'bg-purple-50 text-purple-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
-                                    }`}
+                                    className={`rounded-lg px-3 py-2 text-sm font-semibold whitespace-nowrap transition-all ${isActive('/ordenes') ? 'bg-purple-50 text-purple-700 shadow-sm' : 'text-gray-700 hover:bg-gray-100'
+                                        }`}
                                 >
                                     🚗 Órdenes de Trabajo
                                 </Link>
@@ -313,9 +296,8 @@ export default function DashboardLayout({ children, title }: Props) {
                                         <Link
                                             href="/resumen-del-dia"
                                             onClick={() => setMoreMenuOpen(false)}
-                                            className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                isActive('/resumen-del-dia') ? 'font-medium text-blue-700' : 'text-gray-700'
-                                            }`}
+                                            className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/resumen-del-dia') ? 'font-medium text-blue-700' : 'text-gray-700'
+                                                }`}
                                         >
                                             🧾 Resumen del día
                                         </Link>
@@ -326,27 +308,24 @@ export default function DashboardLayout({ children, title }: Props) {
                                                 <Link
                                                     href="/clientes"
                                                     onClick={() => setMoreMenuOpen(false)}
-                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                        isActive('/clientes') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                    }`}
+                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/clientes') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                        }`}
                                                 >
                                                     👥 Clientes
                                                 </Link>
                                                 <Link
                                                     href="/catalogo-vehiculos"
                                                     onClick={() => setMoreMenuOpen(false)}
-                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                        isActive('/catalogo-vehiculos') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                    }`}
+                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/catalogo-vehiculos') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                        }`}
                                                 >
                                                     🚙 Vehículos
                                                 </Link>
                                                 <Link
                                                     href="/companias-seguros"
                                                     onClick={() => setMoreMenuOpen(false)}
-                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                        isActive('/companias-seguros') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                    }`}
+                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/companias-seguros') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                        }`}
                                                 >
                                                     🛡️ Seguros
                                                 </Link>
@@ -359,9 +338,8 @@ export default function DashboardLayout({ children, title }: Props) {
                                                 <Link
                                                     href="/medio-de-pago"
                                                     onClick={() => setMoreMenuOpen(false)}
-                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                        isActive('/medio-de-pago') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                    }`}
+                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/medio-de-pago') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                        }`}
                                                 >
                                                     💳 Medios de pago
                                                 </Link>
@@ -369,27 +347,24 @@ export default function DashboardLayout({ children, title }: Props) {
                                                 <Link
                                                     href="/conceptos"
                                                     onClick={() => setMoreMenuOpen(false)}
-                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                        isActive('/conceptos') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                    }`}
+                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/conceptos') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                        }`}
                                                 >
                                                     🏷️ Conceptos
                                                 </Link>
                                                 <Link
                                                     href="/admin/metrics"
                                                     onClick={() => setMoreMenuOpen(false)}
-                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                        isActive('/admin/metrics') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                    }`}
+                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/admin/metrics') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                        }`}
                                                 >
                                                     📈 Métricas
                                                 </Link>
                                                 <Link
                                                     href="/admin/users"
                                                     onClick={() => setMoreMenuOpen(false)}
-                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${
-                                                        isActive('/admin/users') ? 'font-medium text-orange-600' : 'text-gray-700'
-                                                    }`}
+                                                    className={`block px-4 py-2 text-sm hover:bg-gray-50 ${isActive('/admin/users') ? 'font-medium text-orange-600' : 'text-gray-700'
+                                                        }`}
                                                 >
                                                     👤 Usuarios
                                                 </Link>
@@ -430,43 +405,38 @@ export default function DashboardLayout({ children, title }: Props) {
                         <div className="space-y-1 px-4 py-2">
                             <Link
                                 href="/admin"
-                                className={`block rounded-lg px-4 py-2 font-semibold ${
-                                    isActive('/admin') && !isActive('/admin/users') ? 'bg-blue-50 text-blue-700' : 'text-gray-700 hover:bg-gray-100'
-                                }`}
+                                className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/admin') && !isActive('/admin/users') ? 'bg-blue-50 text-blue-700' : 'text-gray-700 hover:bg-gray-100'
+                                    }`}
                             >
                                 📊 Panel de Control
                             </Link>
 
                             <Link
                                 href="/egresos"
-                                className={`block rounded-lg px-4 py-2 font-semibold ${
-                                    isActive('/egresos') ? 'bg-red-50 text-red-700' : 'text-gray-700 hover:bg-gray-100'
-                                }`}
+                                className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/egresos') ? 'bg-red-50 text-red-700' : 'text-gray-700 hover:bg-gray-100'
+                                    }`}
                             >
                                 💸 Egresos
                             </Link>
                             <Link
                                 href="/ingresos"
-                                className={`block rounded-lg px-4 py-2 font-semibold ${
-                                    isActive('/ingresos') ? 'bg-green-50 text-green-700' : 'text-gray-700 hover:bg-gray-100'
-                                }`}
+                                className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/ingresos') ? 'bg-green-50 text-green-700' : 'text-gray-700 hover:bg-gray-100'
+                                    }`}
                             >
                                 💰 Ingresos
                             </Link>
                             <Link
                                 href="/resumen-del-dia"
-                                className={`block rounded-lg px-4 py-2 font-semibold ${
-                                    isActive('/resumen-del-dia') ? 'bg-blue-50 text-blue-700' : 'text-gray-700 hover:bg-gray-100'
-                                }`}
+                                className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/resumen-del-dia') ? 'bg-blue-50 text-blue-700' : 'text-gray-700 hover:bg-gray-100'
+                                    }`}
                             >
                                 🧾 Resumen del día
                             </Link>
 
                             <Link
                                 href="/ordenes"
-                                className={`block rounded-lg px-4 py-2 font-semibold ${
-                                    isActive('/ordenes') ? 'bg-purple-50 text-purple-700' : 'text-gray-700 hover:bg-gray-100'
-                                }`}
+                                className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/ordenes') ? 'bg-purple-50 text-purple-700' : 'text-gray-700 hover:bg-gray-100'
+                                    }`}
                             >
                                 🚗 Órdenes de Trabajo
                             </Link>
@@ -477,25 +447,22 @@ export default function DashboardLayout({ children, title }: Props) {
                                     <div className="px-4 py-2 text-xs font-bold text-gray-400 uppercase">⚙️ Administración</div>
                                     <Link
                                         href="/clientes"
-                                        className={`block rounded-lg px-4 py-2 font-semibold ${
-                                            isActive('/clientes') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
-                                        }`}
+                                        className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/clientes') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
+                                            }`}
                                     >
                                         👥 Clientes
                                     </Link>
                                     <Link
                                         href="/catalogo-vehiculos"
-                                        className={`block rounded-lg px-4 py-2 font-semibold ${
-                                            isActive('/catalogo-vehiculos') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
-                                        }`}
+                                        className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/catalogo-vehiculos') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
+                                            }`}
                                     >
                                         🚙 Vehículos
                                     </Link>
                                     <Link
                                         href="/companias-seguros"
-                                        className={`block rounded-lg px-4 py-2 font-semibold ${
-                                            isActive('/companias-seguros') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
-                                        }`}
+                                        className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/companias-seguros') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
+                                            }`}
                                     >
                                         🛡️ Seguros
                                     </Link>
@@ -507,34 +474,30 @@ export default function DashboardLayout({ children, title }: Props) {
                                     </Link>
                                     <Link
                                         href="/medio-de-pago"
-                                        className={`block rounded-lg px-4 py-2 font-semibold ${
-                                            isActive('/medio-de-pago') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
-                                        }`}
+                                        className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/medio-de-pago') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
+                                            }`}
                                     >
                                         💳 Medios de pago
                                     </Link>
                                     {/* 🏷️ CONCEPTOS */}
                                     <Link
                                         href="/conceptos"
-                                        className={`block rounded-lg px-4 py-2 font-semibold ${
-                                            isActive('/conceptos') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
-                                        }`}
+                                        className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/conceptos') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
+                                            }`}
                                     >
                                         🏷️ Conceptos
                                     </Link>
                                     <Link
                                         href="/admin/metrics"
-                                        className={`block rounded-lg px-4 py-2 font-semibold ${
-                                            isActive('/admin/metrics') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
-                                        }`}
+                                        className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/admin/metrics') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
+                                            }`}
                                     >
                                         📈 Métricas
                                     </Link>
                                     <Link
                                         href="/admin/users"
-                                        className={`block rounded-lg px-4 py-2 font-semibold ${
-                                            isActive('/admin/users') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
-                                        }`}
+                                        className={`block rounded-lg px-4 py-2 font-semibold ${isActive('/admin/users') ? 'bg-orange-50 text-orange-700' : 'text-gray-700 hover:bg-gray-100'
+                                            }`}
                                     >
                                         👤 Usuarios
                                     </Link>

--- a/resources/js/pages/conceptos/index.tsx
+++ b/resources/js/pages/conceptos/index.tsx
@@ -15,6 +15,7 @@ type Concepto = {
     id: number;
     nombre: string;
     tipo: "ingreso" | "egreso";
+    sistema: boolean;
     movimientos_count: number;
 };
 
@@ -286,10 +287,16 @@ export default function ConceptosIndex({ conceptos, filters, stats }: PageProps)
                                                 </span>
                                             </td>
                                             <td className="px-6 py-4 text-right">
-                                                <div className="flex justify-end gap-2">
-                                                    <EditButton onClick={() => openEditModal(concepto)} />
-                                                    <DeleteButton onClick={() => openDeleteModal(concepto)} />
-                                                </div>
+                                                {concepto.sistema ? (
+                                                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-slate-100 text-slate-500">
+                                                        🔒 Sistema
+                                                    </span>
+                                                ) : (
+                                                    <div className="flex justify-end gap-2">
+                                                        <EditButton onClick={() => openEditModal(concepto)} />
+                                                        <DeleteButton onClick={() => openDeleteModal(concepto)} />
+                                                    </div>
+                                                )}
                                             </td>
                                         </tr>
                                     ))}

--- a/resources/js/pages/ordenes/createOrdenes.tsx
+++ b/resources/js/pages/ordenes/createOrdenes.tsx
@@ -180,17 +180,28 @@ export default function CreateOrdenes({ titulares, estados, mediosDePago, articu
                 errores[`detalles.${idx}.valor`] = 'Sin precio';
                 hayErrores = true;
             }
+
+            // Validar atributos obligatorios
+            if (d.articulo_id) {
+                const art = articulos.find((a: any) => a.id === d.articulo_id);
+                if (art?.categorias) {
+                    art.categorias.forEach((cat: any) => {
+                        if (cat.obligatoria && !d.atributos?.[cat.id]) {
+                            errores[`detalles.${idx}.atributos.${cat.id}`] = ' ';
+                            hayErrores = true;
+                        }
+                    });
+                }
+            }
         });
 
         setLocalErrors(errores);
 
         if (hayErrores) {
-            const mensajesError: string[] = [];
-            if (errores['fecha_entrega_estimada']) mensajesError.push('Ingresá una fecha de entrega estimada.');
-            if (errores['estado_id']) mensajesError.push('Seleccioná un estado para la orden.');
-            if (Object.keys(errores).some(k => k.startsWith('detalles.'))) mensajesError.push('Hay artículos sin precio.');
-
-            toast.error(mensajesError.join('\n'));
+            if (errores['fecha_entrega_estimada']) toast.error(errores['fecha_entrega_estimada']);
+            if (errores['estado_id']) toast.error(errores['estado_id']);
+            if (Object.keys(errores).some(k => k.match(/^detalles\.\d+\.valor$/))) toast.error('Hay artículos sin precio.');
+            if (Object.keys(errores).some(k => k.match(/^detalles\.\d+\.atributos\./))) toast.error('Completá los atributos del artículo que son obligatorios marcados en rojo.');
             return;
         }
 

--- a/resources/js/pages/ordenes/edit.tsx
+++ b/resources/js/pages/ordenes/edit.tsx
@@ -66,13 +66,13 @@ type FormData = {
   nuevo_vehiculo: any | null;
   detalles: DetalleUI[];
   pagos: Array<{
-      id?: number;
-      medio_de_pago_id: number | string;
-      monto: number | string;
-      fecha: string;
-      pagado: boolean;
-      bloqueado?: boolean;
-      observacion: string;
+    id?: number;
+    medio_de_pago_id: number | string;
+    monto: number | string;
+    fecha: string;
+    pagado: boolean;
+    bloqueado?: boolean;
+    observacion: string;
   }>;
 };
 
@@ -139,13 +139,13 @@ export default function Edit({
     }) as DetalleUI[],
 
     pagos: (orden.pagos || []).map((p) => ({
-        id: p.id,
-        medio_de_pago_id: p.medio_de_pago_id,
-        monto: p.valor ?? 0,
-        fecha: p.fecha ? String(p.fecha).substring(0, 10) : getArgentinaToday(),
-        pagado: p.pagado ?? false,
-        bloqueado: p.bloqueado ?? false,
-        observacion: p.observacion ?? "",
+      id: p.id,
+      medio_de_pago_id: p.medio_de_pago_id,
+      monto: p.valor ?? 0,
+      fecha: p.fecha ? String(p.fecha).substring(0, 10) : getArgentinaToday(),
+      pagado: p.pagado ?? false,
+      bloqueado: p.bloqueado ?? false,
+      observacion: p.observacion ?? "",
     })),
   };
 
@@ -189,13 +189,41 @@ export default function Edit({
     setData((prev: FormData) => ({ ...prev, ...patch }));
   };
 
+  const [localErrors, setLocalErrors] = React.useState<Record<string, string>>({});
+  const allErrors = { ...uiErrors, ...localErrors };
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
 
     const fe = (data as any).fecha_entrega_estimada;
 
-    if (!fe) return alert("Completá la fecha de entrega estimada.");
-    if (data.fecha && fe < data.fecha) return alert("La fecha estimada no puede ser anterior a la fecha.");
+    if (!fe) return toast.error("Completá la fecha de entrega estimada.");
+    if (data.fecha && fe < data.fecha) return toast.error("La fecha estimada no puede ser anterior a la fecha.");
+
+    // Validar atributos obligatorios
+    const errores: Record<string, string> = {};
+    let hayErrores = false;
+
+    data.detalles.forEach((d, idx) => {
+      if (d.articulo_id) {
+        const art = articulos.find((a: any) => a.id === d.articulo_id);
+        if (art?.categorias) {
+          art.categorias.forEach((cat: any) => {
+            if (cat.obligatoria && !d.atributos?.[cat.id]) {
+              errores[`detalles.${idx}.atributos.${cat.id}`] = ' ';
+              hayErrores = true;
+            }
+          });
+        }
+      }
+    });
+
+    setLocalErrors(errores);
+
+    if (hayErrores) {
+      if (Object.keys(errores).some(k => k.match(/^detalles\.\d+\.atributos\./))) toast.error('Completá los atributos del artículo que son obligatorios marcados en rojo.');
+      return;
+    }
 
     put(`/ordenes/${orden.id}`, {
       onError: (errs) => console.log("Errores:", errs),
@@ -347,7 +375,7 @@ export default function Edit({
           <DetallesSection
             detalles={data.detalles}
             articulos={articulos}
-            errors={uiErrors}
+            errors={allErrors}
             setDetalles={(nuevos: DetalleUI[]) => {
               setData((prev: FormData) => ({
                 ...prev,
@@ -359,14 +387,14 @@ export default function Edit({
           {/* Pagos */}
           <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
             <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-                <PagosSection
-                    pagos={data.pagos}
-                    setPagos={(pagos) => setData((prev: FormData) => ({ ...prev, pagos }))}
-                    mediosDePago={mediosDePago}
-                    totalOrden={totalOrden}
-                    errors={errors as Record<string, string>}
-                    modoEdicion={true}
-                />
+              <PagosSection
+                pagos={data.pagos}
+                setPagos={(pagos) => setData((prev: FormData) => ({ ...prev, pagos }))}
+                mediosDePago={mediosDePago}
+                totalOrden={totalOrden}
+                errors={errors as Record<string, string>}
+                modoEdicion={true}
+              />
             </div>
 
             <div className="mt-4 flex justify-end">

--- a/resources/js/pages/ordenes/index.tsx
+++ b/resources/js/pages/ordenes/index.tsx
@@ -5,6 +5,7 @@ import EditButton from "@/components/botones/boton-editar";
 import ViewButton from "@/components/botones/boton-ver";
 import { formatDateToArgentina } from "@/utils/dateFormat";
 import { CheckCircle, AlertCircle } from "lucide-react";
+import ConfirmAnularModal from "@/components/ConfirmAnularModal";
 
 type Vehiculo = {
   id: number;
@@ -70,9 +71,12 @@ export default function Index({ ordenes }: { ordenes: any }) {
   const listaOrdenes: Orden[] = ordenes?.data || [];
   const links = ordenes?.links || [];
 
-  function handleAnular(id: number) {
-    if (confirm('¿Seguro que querés anular esta orden?\n\nSi ya generó ingresos, se crearán movimientos de reversa.')) {
-      destroy(`/ordenes/${id}`);
+  const [anularOrdenId, setAnularOrdenId] = useState<number | null>(null);
+
+  function handleAnularConfirm() {
+    if (anularOrdenId !== null) {
+      destroy(`/ordenes/${anularOrdenId}`);
+      setAnularOrdenId(null);
     }
   }
 
@@ -434,7 +438,7 @@ export default function Index({ ordenes }: { ordenes: any }) {
                             )}
                             {orden.estado?.nombre !== 'Finalizada' && orden.estado?.nombre !== 'Anulada' && (
                               <button
-                                onClick={() => handleAnular(orden.id)}
+                                onClick={() => setAnularOrdenId(orden.id)}
                                 className="rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-medium text-red-700 transition hover:bg-red-100"
                               >
                                 Anular
@@ -504,6 +508,16 @@ export default function Index({ ordenes }: { ordenes: any }) {
           )}
         </div>
       </div>
+
+      {/* Modal de confirmación de anulación */}
+      {anularOrdenId !== null && (
+        <ConfirmAnularModal
+          open={true}
+          onClose={() => setAnularOrdenId(null)}
+          onConfirm={handleAnularConfirm}
+          ordenId={anularOrdenId}
+        />
+      )}
     </DashboardLayout>
   );
 }

--- a/resources/js/pages/ordenes/index.tsx
+++ b/resources/js/pages/ordenes/index.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { Head, Link, useForm, router, usePage } from "@inertiajs/react";
 import DashboardLayout from "@/layouts/DashboardLayout";
-import DeleteButton from "@/components/botones/boton-eliminar";
 import EditButton from "@/components/botones/boton-editar";
 import ViewButton from "@/components/botones/boton-ver";
 import { formatDateToArgentina } from "@/utils/dateFormat";
@@ -71,8 +70,8 @@ export default function Index({ ordenes }: { ordenes: any }) {
   const listaOrdenes: Orden[] = ordenes?.data || [];
   const links = ordenes?.links || [];
 
-  function handleDelete(id: number) {
-    if (confirm("¿Seguro que querés eliminar esta orden?")) {
+  function handleAnular(id: number) {
+    if (confirm('¿Seguro que querés anular esta orden?\n\nSi ya generó ingresos, se crearán movimientos de reversa.')) {
       destroy(`/ordenes/${id}`);
     }
   }
@@ -397,7 +396,7 @@ export default function Index({ ordenes }: { ordenes: any }) {
                     {listaOrdenes.map((orden: Orden) => (
                       <tr
                         key={orden.id}
-                        className="hover:bg-gray-50 transition"
+                        className={`hover:bg-gray-50 transition ${orden.estado?.nombre === 'Anulada' ? 'opacity-60' : ''}`}
                       >
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                           {formatDateToArgentina(orden.fecha)}
@@ -413,7 +412,10 @@ export default function Index({ ordenes }: { ordenes: any }) {
                             : "Sin vehículo"}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
-                          <span className="px-2 py-1 rounded text-white text-xs bg-blue-500">
+                          <span className={`px-2 py-1 rounded text-white text-xs ${orden.estado?.nombre === 'Anulada' ? 'bg-red-500' :
+                            orden.estado?.nombre === 'Finalizada' ? 'bg-green-500' :
+                              'bg-blue-500'
+                            }`}>
                             {orden.estado?.nombre ?? "-"}
                           </span>
                         </td>
@@ -425,12 +427,19 @@ export default function Index({ ordenes }: { ordenes: any }) {
                             <ViewButton
                               onClick={() => router.visit(`/ordenes/${orden.id}?return=${encodeURIComponent(returnUrl)}`)}
                             />
-                            <EditButton
-                              onClick={() => router.visit(`/ordenes/${orden.id}/edit?return=${encodeURIComponent(returnUrl)}`)}
-                            />
-                            <DeleteButton
-                              onClick={() => handleDelete(orden.id)}
-                            />
+                            {orden.estado?.nombre !== 'Finalizada' && orden.estado?.nombre !== 'Anulada' && (
+                              <EditButton
+                                onClick={() => router.visit(`/ordenes/${orden.id}/edit?return=${encodeURIComponent(returnUrl)}`)}
+                              />
+                            )}
+                            {orden.estado?.nombre !== 'Finalizada' && orden.estado?.nombre !== 'Anulada' && (
+                              <button
+                                onClick={() => handleAnular(orden.id)}
+                                className="rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-medium text-red-700 transition hover:bg-red-100"
+                              >
+                                Anular
+                              </button>
+                            )}
                           </div>
                         </td>
                       </tr>

--- a/resources/js/pages/ordenes/show.tsx
+++ b/resources/js/pages/ordenes/show.tsx
@@ -265,22 +265,22 @@ export default function Show({
 
               <div className="p-6">
                 {/* Resumen visual */}
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-                  <div className="bg-slate-50 rounded-xl p-4 border border-slate-200">
+                <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+                  <div className="bg-slate-50 rounded-xl p-4 border border-slate-200 min-w-0">
                     <p className="text-sm text-slate-600 mb-1">Total de la orden</p>
-                    <p className="text-2xl font-bold text-slate-900">${totalOrden.toLocaleString("es-AR")}</p>
+                    <p className="text-base font-bold text-slate-900 break-all">${totalOrden.toLocaleString("es-AR")}</p>
                   </div>
-                  <div className="bg-green-50 rounded-xl p-4 border border-green-200">
+                  <div className="bg-green-50 rounded-xl p-4 border border-green-200 min-w-0">
                     <p className="text-sm text-green-700 mb-1">Total cobrado</p>
-                    <p className="text-2xl font-bold text-green-600">${totalPagado.toLocaleString("es-AR")}</p>
+                    <p className="text-base font-bold text-green-600 break-all">${totalPagado.toLocaleString("es-AR")}</p>
                   </div>
-                  <div className="bg-blue-50 rounded-xl p-4 border border-blue-200">
+                  <div className="bg-blue-50 rounded-xl p-4 border border-blue-200 min-w-0">
                     <p className="text-sm text-blue-700 mb-1">Registrado sin cobrar</p>
-                    <p className="text-2xl font-bold text-blue-600">${(totalRegistrado - totalPagado).toLocaleString("es-AR")}</p>
+                    <p className="text-base font-bold text-blue-600 break-all">${(totalRegistrado - totalPagado).toLocaleString("es-AR")}</p>
                   </div>
-                  <div className={`rounded-xl p-4 border ${saldoPendiente > 0 ? 'bg-red-50 border-red-200' : saldoPendiente < 0 ? 'bg-blue-50 border-blue-200' : 'bg-green-50 border-green-200'}`}>
+                  <div className={`rounded-xl p-4 border min-w-0 ${saldoPendiente > 0 ? 'bg-red-50 border-red-200' : saldoPendiente < 0 ? 'bg-blue-50 border-blue-200' : 'bg-green-50 border-green-200'}`}>
                     <p className={`text-sm mb-1 ${saldoPendiente > 0 ? 'text-red-700' : saldoPendiente < 0 ? 'text-blue-700' : 'text-green-700'}`}>Saldo pendiente</p>
-                    <p className={`text-2xl font-bold ${saldoPendiente > 0 ? 'text-red-600' : saldoPendiente < 0 ? 'text-blue-600' : 'text-green-600'}`}>
+                    <p className={`text-base font-bold break-all ${saldoPendiente > 0 ? 'text-red-600' : saldoPendiente < 0 ? 'text-blue-600' : 'text-green-600'}`}>
                       ${Math.abs(saldoPendiente).toLocaleString("es-AR")}
                     </p>
                   </div>

--- a/resources/js/pages/ordenes/show.tsx
+++ b/resources/js/pages/ordenes/show.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link, Head, router } from "@inertiajs/react";
 import DashboardLayout from "@/layouts/DashboardLayout";
 import { User, Phone, Mail, Car, Calendar, FileText, DollarSign, CreditCard, AlertCircle, CheckCircle, ArrowLeft, Printer, Lock, Ban } from "lucide-react";
 import PrintableODT from "@/components/print/PrintableODT";
 import { formatDateToArgentina, formatDateTimeToArgentina } from '@/utils/dateFormat';
+import ConfirmAnularModal from "@/components/ConfirmAnularModal";
 
 type Atributo = {
   id: number;
@@ -77,10 +78,11 @@ export default function Show({
   const isFinalizada = orden.estado.nombre === 'Finalizada';
   const canModify = !isAnulada && !isFinalizada;
 
+  const [showAnularModal, setShowAnularModal] = useState(false);
+
   function handleAnular() {
-    if (confirm('¿Estás seguro de que querés anular esta orden?\n\nSi la OT ya generó ingresos en caja, se crearán movimientos de reversa (egresos) para compensar.')) {
-      router.delete(`/ordenes/${orden.id}`);
-    }
+    router.delete(`/ordenes/${orden.id}`);
+    setShowAnularModal(false);
   }
 
   return (
@@ -146,7 +148,7 @@ export default function Show({
             )}
             {canModify && (
               <button
-                onClick={handleAnular}
+                onClick={() => setShowAnularModal(true)}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-xl font-medium hover:bg-red-700 transition shadow-md hover:shadow-lg"
               >
                 <Ban className="w-4 h-4" />
@@ -310,10 +312,10 @@ export default function Show({
                         <div
                           key={pago.id}
                           className={`flex items-start justify-between p-4 rounded-xl border transition ${pago.bloqueado
-                              ? 'bg-slate-50/50 border-slate-300'
-                              : pago.pagado
-                                ? 'bg-green-50/50 border-green-200'
-                                : 'bg-gray-50 border-gray-100 hover:border-gray-200'
+                            ? 'bg-slate-50/50 border-slate-300'
+                            : pago.pagado
+                              ? 'bg-green-50/50 border-green-200'
+                              : 'bg-gray-50 border-gray-100 hover:border-gray-200'
                             }`}
                         >
                           <div className="flex gap-4 flex-1">
@@ -560,6 +562,14 @@ export default function Show({
 
       {/* Componente de impresión profesional */}
       <PrintableODT orden={orden as any} />
+
+      {/* Modal de confirmación de anulación */}
+      <ConfirmAnularModal
+        open={showAnularModal}
+        onClose={() => setShowAnularModal(false)}
+        onConfirm={handleAnular}
+        ordenId={orden.id}
+      />
     </DashboardLayout>
   );
 }

--- a/resources/js/pages/ordenes/show.tsx
+++ b/resources/js/pages/ordenes/show.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Link, Head } from "@inertiajs/react";
+import { Link, Head, router } from "@inertiajs/react";
 import DashboardLayout from "@/layouts/DashboardLayout";
-import { User, Phone, Mail, Car, Calendar, FileText, DollarSign, CreditCard, AlertCircle, CheckCircle, ArrowLeft, Printer, Lock } from "lucide-react";
+import { User, Phone, Mail, Car, Calendar, FileText, DollarSign, CreditCard, AlertCircle, CheckCircle, ArrowLeft, Printer, Lock, Ban } from "lucide-react";
 import PrintableODT from "@/components/print/PrintableODT";
 import { formatDateToArgentina, formatDateTimeToArgentina } from '@/utils/dateFormat';
 
@@ -56,28 +56,49 @@ type HistorialEstado = {
   user?: { id: number; name: string } | null;
 };
 
-export default function Show({ 
-    orden, 
-    totalOrden = 0,
-    totalPagado = 0,
-    totalRegistrado = 0,
-    saldoPendiente = 0
-}: { 
-    orden: Orden;
-    totalOrden?: number;
-    totalPagado?: number;
-    totalRegistrado?: number;
-    saldoPendiente?: number;
+export default function Show({
+  orden,
+  totalOrden = 0,
+  totalPagado = 0,
+  totalRegistrado = 0,
+  saldoPendiente = 0
+}: {
+  orden: Orden;
+  totalOrden?: number;
+  totalPagado?: number;
+  totalRegistrado?: number;
+  saldoPendiente?: number;
 }) {
 
   const companiaNombre =
     (orden as any).compania_seguro?.nombre ?? "Sin seguro / Particular";
+
+  const isAnulada = orden.estado.nombre === 'Anulada';
+  const isFinalizada = orden.estado.nombre === 'Finalizada';
+  const canModify = !isAnulada && !isFinalizada;
+
+  function handleAnular() {
+    if (confirm('¿Estás seguro de que querés anular esta orden?\n\nSi la OT ya generó ingresos en caja, se crearán movimientos de reversa (egresos) para compensar.')) {
+      router.delete(`/ordenes/${orden.id}`);
+    }
+  }
 
   return (
     <DashboardLayout>
       <Head title={`Orden #${orden.id}`} />
 
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 print:hidden">
+        {/* Banner Anulada */}
+        {isAnulada && (
+          <div className="mb-6 flex items-center gap-3 rounded-2xl border border-red-200 bg-red-50 px-6 py-4">
+            <Ban className="w-6 h-6 text-red-500 flex-shrink-0" />
+            <div>
+              <p className="font-bold text-red-800">Orden Anulada</p>
+              <p className="text-sm text-red-600">Esta orden fue anulada. Los movimientos de reversa fueron generados automáticamente.</p>
+            </div>
+          </div>
+        )}
+
         {/* Header */}
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-8">
           <div className="flex items-center gap-3">
@@ -115,12 +136,23 @@ export default function Show({
               <Printer className="w-4 h-4" />
               Imprimir
             </button>
-            <Link
-              href={`/ordenes/${orden.id}/edit`}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-xl font-medium hover:bg-green-700 transition shadow-md hover:shadow-lg"
-            >
-              Editar Orden
-            </Link>
+            {canModify && (
+              <Link
+                href={`/ordenes/${orden.id}/edit`}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-xl font-medium hover:bg-green-700 transition shadow-md hover:shadow-lg"
+              >
+                Editar Orden
+              </Link>
+            )}
+            {canModify && (
+              <button
+                onClick={handleAnular}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-xl font-medium hover:bg-red-700 transition shadow-md hover:shadow-lg"
+              >
+                <Ban className="w-4 h-4" />
+                Anular
+              </button>
+            )}
           </div>
         </div>
 
@@ -228,7 +260,7 @@ export default function Show({
                   </span>
                 )}
               </div>
-              
+
               <div className="p-6">
                 {/* Resumen visual */}
                 <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
@@ -262,9 +294,8 @@ export default function Show({
                   </div>
                   <div className="w-full bg-slate-200 rounded-full h-3 overflow-hidden">
                     <div
-                      className={`h-full rounded-full transition-all duration-500 ${
-                        totalPagado >= totalOrden ? 'bg-green-500' : totalPagado > 0 ? 'bg-yellow-500' : 'bg-red-500'
-                      }`}
+                      className={`h-full rounded-full transition-all duration-500 ${totalPagado >= totalOrden ? 'bg-green-500' : totalPagado > 0 ? 'bg-yellow-500' : 'bg-red-500'
+                        }`}
                       style={{ width: `${totalOrden > 0 ? Math.min((totalPagado / totalOrden) * 100, 100) : 0}%` }}
                     />
                   </div>
@@ -276,15 +307,14 @@ export default function Show({
                   {orden.pagos.length > 0 ? (
                     <div className="space-y-3">
                       {orden.pagos.map((pago) => (
-                        <div 
-                          key={pago.id} 
-                          className={`flex items-start justify-between p-4 rounded-xl border transition ${
-                            pago.bloqueado 
+                        <div
+                          key={pago.id}
+                          className={`flex items-start justify-between p-4 rounded-xl border transition ${pago.bloqueado
                               ? 'bg-slate-50/50 border-slate-300'
-                              : pago.pagado 
-                                ? 'bg-green-50/50 border-green-200' 
+                              : pago.pagado
+                                ? 'bg-green-50/50 border-green-200'
                                 : 'bg-gray-50 border-gray-100 hover:border-gray-200'
-                          }`}
+                            }`}
                         >
                           <div className="flex gap-4 flex-1">
                             {/* Badge de bloqueado */}
@@ -297,9 +327,8 @@ export default function Show({
 
                             {/* Estado de cobro */}
                             {!pago.bloqueado && (
-                              <div className={`flex flex-col items-center justify-center px-3 py-2 rounded-lg border shadow-sm min-w-[90px] ${
-                                pago.pagado ? 'bg-green-100 border-green-300' : 'bg-slate-100 border-slate-300'
-                              }`}>
+                              <div className={`flex flex-col items-center justify-center px-3 py-2 rounded-lg border shadow-sm min-w-[90px] ${pago.pagado ? 'bg-green-100 border-green-300' : 'bg-slate-100 border-slate-300'
+                                }`}>
                                 {pago.pagado ? (
                                   <>
                                     <CheckCircle className="w-5 h-5 text-green-600 mb-1" />
@@ -337,9 +366,8 @@ export default function Show({
                           </div>
 
                           {/* Monto */}
-                          <span className={`font-bold text-lg ml-4 ${
-                            Number(pago.valor) < 0 ? 'text-red-600' : 'text-gray-900'
-                          }`}>
+                          <span className={`font-bold text-lg ml-4 ${Number(pago.valor) < 0 ? 'text-red-600' : 'text-gray-900'
+                            }`}>
                             {Number(pago.valor) < 0 ? '-' : ''}${Math.abs(Number(pago.valor)).toLocaleString("es-AR")}
                           </span>
                         </div>
@@ -373,7 +401,7 @@ export default function Show({
                     <div className="flex-1">
                       <p className="text-sm font-medium text-amber-900">Pago incompleto</p>
                       <p className="text-sm text-amber-700 mt-1">
-                        Esta orden tiene un saldo pendiente de ${saldoPendiente.toLocaleString("es-AR")}. 
+                        Esta orden tiene un saldo pendiente de ${saldoPendiente.toLocaleString("es-AR")}.
                         No podrá ser finalizada hasta completar el cobro total.
                       </p>
                     </div>
@@ -407,7 +435,7 @@ export default function Show({
                   <div className="space-y-6">
                     {orden.historial_estados.map((h, index) => (
                       <div key={h.id} className="relative pl-6">
-                        
+
                         {/* Línea vertical */}
                         {index !== orden.historial_estados!.length - 1 && (
                           <div className="absolute left-2 top-4 bottom-0 w-px bg-gray-200"></div>


### PR DESCRIPTION
# PR: Anulación de OTs + Mejoras varias

## Anulación de Órdenes de Trabajo

- Se puede **anular** una OT desde el listado o desde la vista detalle
- Si la OT ya generó ingresos en caja, se crean **egresos de reversa automáticos** para compensar
- Las OTs anuladas se muestran con badge rojo y opacidad reducida en el listado
- En la vista detalle aparece un banner indicando que la orden fue anulada
- No se puede editar ni anular una OT que ya está anulada o finalizada
- Las OTs anuladas no se cuentan en las métricas de "OTs creadas"

## Modal de confirmación

- Se creó un modal para anular una OT con ícono de advertencia y botones estilizados

## Conceptos del sistema

- Los conceptos que el código usa internamente (ej: "Anulación OT") ahora están marcados como **🔒 Sistema**
- No se pueden editar ni eliminar desde el ABM
- Los conceptos que tienen movimientos asociados tampoco se pueden eliminar 

## Fixes

- Montos grandes ya no se cortan en las tarjetas de "Estado de Pago"
- En el listado, las OTs creadas el mismo día ahora aparecen las más recientes primero
- El link de "Conceptos" en el menú de Administración  

## Validaciones en el ABM de OT (todas con borde rojo)

- Falta fecha de entrega ->"Ingresá una fecha de entrega estimada."
- Fecha estimada menor a la orden -> "La fecha de entrega no puede ser anterior..."
- Falta estado -> "Seleccioná un estado para la orden."
- Artículos sin precio -> "Hay artículos sin precio."
- Atributos obligatorios vacíos -> "Completá los atributos obligatorios marcados en rojo."
- Falta cliente -> "Por favor completá los datos del cliente."
- Falta vehiculo -> "Por favor completá los datos del vehiculo."

