### PR TITLE
Soporte de Horas y Minutos en Fechas + Numeración Correlativa Automatizada en O.T.

### DIFF
--- a/app/Http/Controllers/OrdenDeTrabajoController.php
+++ b/app/Http/Controllers/OrdenDeTrabajoController.php
@@ -272,12 +272,24 @@ class OrdenDeTrabajoController extends Controller
                 'vehiculo_id' => $data['vehiculo_id'],
             ]);
 
+            $prefix = $conFactura ? 'FC-' : 'OT-';
+            $lastOrder = OrdenDeTrabajo::where('numero_orden', 'like', $prefix . '%')
+                ->lockForUpdate()
+                ->orderByRaw('CAST(SUBSTRING(numero_orden, 4) AS UNSIGNED) DESC')
+                ->first();
+
+            $newNumber = 1;
+            if ($lastOrder && preg_match('/^' . $prefix . '(\d+)$/', $lastOrder->numero_orden, $matches)) {
+                $newNumber = (int) $matches[1] + 1;
+            }
+            $numeroCorrelativo = $prefix . str_pad($newNumber, 6, '0', STR_PAD_LEFT);
+
             $orden = OrdenDeTrabajo::create([
                 'titular_vehiculo_id' => $pivot->id,
                 'estado_id' => $validated['estado_id'],
                 'fecha' => $validated['fecha'],
                 'fecha_entrega_estimada' => $validated['fecha_entrega_estimada'],
-                'numero_orden' => $validated['numero_orden'] ?? null,
+                'numero_orden' => $numeroCorrelativo,
                 'con_factura' => $conFactura,
                 'es_garantia' => (bool) ($validated['es_garantia'] ?? false),
                 'observacion' => $validated['observacion'] ?? null,
@@ -461,14 +473,30 @@ class OrdenDeTrabajoController extends Controller
                 'vehiculo_id' => $data['vehiculo_id'],
             ]);
 
+            $conFacturaFinal = (bool) $validated['con_factura'];
+            $prefixFinal = $conFacturaFinal ? 'FC-' : 'OT-';
+            $numeroCorrelativo = $orden->numero_orden;
+
+            if (!$numeroCorrelativo || !str_starts_with($numeroCorrelativo, $prefixFinal)) {
+                $lastOrder = OrdenDeTrabajo::where('numero_orden', 'like', $prefixFinal . '%')
+                    ->lockForUpdate()
+                    ->orderByRaw('CAST(SUBSTRING(numero_orden, 4) AS UNSIGNED) DESC')
+                    ->first();
+                $newNumber = 1;
+                if ($lastOrder && preg_match('/^' . $prefixFinal . '(\d+)$/', $lastOrder->numero_orden, $matches)) {
+                    $newNumber = (int) $matches[1] + 1;
+                }
+                $numeroCorrelativo = $prefixFinal . str_pad($newNumber, 6, '0', STR_PAD_LEFT);
+            }
+
             $orden->update([
                 'titular_vehiculo_id' => $pivot->id,
                 'estado_id' => $validated['estado_id'],
                 'fecha' => $validated['fecha'],
                 'observacion' => $validated['observacion'] ?? null,
-                'con_factura' => (bool) $validated['con_factura'],
+                'con_factura' => $conFacturaFinal,
                 'fecha_entrega_estimada' => $validated['fecha_entrega_estimada'] ?? null,
-                'numero_orden' => $validated['numero_orden'] ?? ($orden->numero_orden ?? null),
+                'numero_orden' => $numeroCorrelativo,
                 'es_garantia' => (bool) ($validated['es_garantia'] ?? false),
                 'compania_seguro_id' => $validated['compania_seguro_id'] ?? null,
             ]);

--- a/app/Models/Movimiento.php
+++ b/app/Models/Movimiento.php
@@ -28,7 +28,7 @@ class Movimiento extends Model
     ];
 
     protected $casts = [
-        'fecha' => 'date:Y-m-d',
+        'fecha' => 'datetime',
         'monto' => 'float',
     ];
 

--- a/app/Models/OrdenDeTrabajo.php
+++ b/app/Models/OrdenDeTrabajo.php
@@ -25,6 +25,7 @@ class OrdenDeTrabajo extends Model
 
     protected $casts = [
         'fecha' => 'datetime',     // en DB es datetime
+        'fecha_entrega_estimada' => 'datetime',
         'con_factura' => 'boolean',
     ];
 

--- a/database/migrations/2026_03_29_182431_alter_fechas_add_time_to_movimiento_and_orden_de_trabajo.php
+++ b/database/migrations/2026_03_29_182431_alter_fechas_add_time_to_movimiento_and_orden_de_trabajo.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('movimiento', function (Blueprint $table) {
+            $table->dateTime('fecha')->change();
+        });
+
+        Schema::table('orden_de_trabajo', function (Blueprint $table) {
+            $table->dateTime('fecha_entrega_estimada')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('movimiento', function (Blueprint $table) {
+            $table->date('fecha')->change();
+        });
+
+        Schema::table('orden_de_trabajo', function (Blueprint $table) {
+            $table->date('fecha_entrega_estimada')->nullable()->change();
+        });
+    }
+};

--- a/resources/js/components/ui/DateTimePicker.tsx
+++ b/resources/js/components/ui/DateTimePicker.tsx
@@ -1,0 +1,325 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Calendar, ChevronLeft, ChevronRight, X, Clock } from 'lucide-react';
+
+interface DateTimePickerProps {
+    value: string; // formato YYYY-MM-DD HH:mm (o Date string de js)
+    onChange: (date: string) => void;
+    minDate?: string; 
+    maxDate?: string; 
+    placeholder?: string;
+    error?: boolean;
+    disabled?: boolean;
+    className?: string;
+}
+
+export default function DateTimePicker({
+    value,
+    onChange,
+    minDate,
+    maxDate,
+    placeholder = 'Seleccionar fecha y hora',
+    error = false,
+    disabled = false,
+    className = '',
+}: DateTimePickerProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [viewDate, setViewDate] = useState(new Date());
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    // Convertir YYYY-MM-DD HH:mm a Date
+    const parseDate = (dateStr: string): Date | null => {
+        if (!dateStr) return null;
+        try {
+            const cleanStr = dateStr.replace('T', ' ');
+            const [datePart, timePart] = cleanStr.split(' ');
+            const [year, month, day] = datePart.split('-').map(Number);
+            let hours = 0, minutes = 0;
+            if (timePart) {
+                const timeParts = timePart.split(':').map(Number);
+                hours = timeParts[0] || 0;
+                minutes = timeParts[1] || 0;
+            }
+            if (isNaN(year) || isNaN(month) || isNaN(day)) {
+                // Try fallback to standard Date parsing
+                const d = new Date(dateStr);
+                if (!isNaN(d.getTime())) return d;
+                return null;
+            }
+            return new Date(year, month - 1, day, hours, minutes);
+        } catch (e) {
+            return null;
+        }
+    };
+
+    // Convertir Date a YYYY-MM-DD HH:mm
+    const formatForBackend = (date: Date): string => {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${year}-${month}-${day} ${hours}:${minutes}`;
+    };
+
+    // Convertir a dd/mm/yyyy hh:mm (para mostrar)
+    const formatForDisplay = (dateStr: string): string => {
+        if (!dateStr) return '';
+        const date = parseDate(dateStr);
+        if (!date) return '';
+        const day = String(date.getDate()).padStart(2, '0');
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const year = date.getFullYear();
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${day}/${month}/${year} ${hours}:${minutes}`;
+    };
+
+    useEffect(() => {
+        if (value) {
+            const date = parseDate(value);
+            if (date && !isNaN(date.getTime())) setViewDate(date);
+        } else {
+            // If empty, set viewDate to current time so when user clicks a day, it gets now's time
+            setViewDate(new Date());
+        }
+    }, [value]);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+            return () => document.removeEventListener('mousedown', handleClickOutside);
+        }
+    }, [isOpen]);
+
+    const handleSelectDate = (day: number) => {
+        const selectedDate = new Date(viewDate.getFullYear(), viewDate.getMonth(), day, viewDate.getHours(), viewDate.getMinutes());
+        const formatted = formatForBackend(selectedDate);
+
+        if (minDate && formatted < minDate) return;
+        if (maxDate && formatted > maxDate) return;
+
+        onChange(formatted);
+        // keep open so they can edit time
+    };
+
+    const handleTimeChange = (type: 'hours' | 'minutes', val: string) => {
+        const num = parseInt(val, 10) || 0;
+        const newDate = new Date(viewDate.getTime());
+        if (type === 'hours') newDate.setHours(Math.max(0, Math.min(23, num)));
+        if (type === 'minutes') newDate.setMinutes(Math.max(0, Math.min(59, num)));
+        
+        setViewDate(newDate);
+        
+        // If an actual date is selected (value has something), update it
+        if (value) {
+            const parsedValue = parseDate(value);
+            if (parsedValue) {
+                const updatedSelectedDate = new Date(parsedValue.getFullYear(), parsedValue.getMonth(), parsedValue.getDate(), newDate.getHours(), newDate.getMinutes());
+                onChange(formatForBackend(updatedSelectedDate));
+            }
+        }
+    };
+
+    const handleClear = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onChange('');
+        setViewDate(new Date());
+    };
+
+    const prevMonth = () => {
+        setViewDate(new Date(viewDate.getFullYear(), viewDate.getMonth() - 1, 1, viewDate.getHours(), viewDate.getMinutes()));
+    };
+
+    const nextMonth = () => {
+        setViewDate(new Date(viewDate.getFullYear(), viewDate.getMonth() + 1, 1, viewDate.getHours(), viewDate.getMinutes()));
+    };
+
+    const getDaysInMonth = (date: Date) => {
+        return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+    };
+
+    const getFirstDayOfMonth = (date: Date) => {
+        return new Date(date.getFullYear(), date.getMonth(), 1).getDay();
+    };
+
+    const renderCalendar = () => {
+        const daysInMonth = getDaysInMonth(viewDate);
+        const firstDay = getFirstDayOfMonth(viewDate);
+        const days = [];
+
+        const selectedDate = value ? parseDate(value) : null;
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
+        for (let i = 0; i < firstDay; i++) {
+            days.push(<div key={`empty-${i}`} className="p-2" />);
+        }
+
+        for (let day = 1; day <= daysInMonth; day++) {
+            const currentDateForCheck = new Date(viewDate.getFullYear(), viewDate.getMonth(), day);
+            const dateStrForCheck = `${currentDateForCheck.getFullYear()}-${String(currentDateForCheck.getMonth() + 1).padStart(2, '0')}-${String(currentDateForCheck.getDate()).padStart(2, '0')}`;
+
+            const isSelected =
+                selectedDate &&
+                currentDateForCheck.getDate() === selectedDate.getDate() &&
+                currentDateForCheck.getMonth() === selectedDate.getMonth() &&
+                currentDateForCheck.getFullYear() === selectedDate.getFullYear();
+
+            const isToday =
+                currentDateForCheck.getDate() === today.getDate() &&
+                currentDateForCheck.getMonth() === today.getMonth() &&
+                currentDateForCheck.getFullYear() === today.getFullYear();
+
+            const isDisabled = false;
+
+            days.push(
+                <button
+                    key={day}
+                    type="button"
+                    onClick={() => handleSelectDate(day)}
+                    disabled={isDisabled}
+                    className={`
+                        p-2 text-sm font-medium rounded-lg transition-all
+                        ${isSelected
+                            ? 'bg-green-600 text-white shadow-md hover:bg-green-700'
+                            : isToday
+                                ? 'bg-blue-50 text-blue-700 hover:bg-blue-100'
+                                : isDisabled
+                                    ? 'text-gray-300 cursor-not-allowed'
+                                    : 'text-gray-700 hover:bg-gray-100'
+                        }
+                    `}
+                >
+                    {day}
+                </button>
+            );
+        }
+
+        return days;
+    };
+
+    const monthNames = [
+        'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+        'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'
+    ];
+
+    const displayValue = formatForDisplay(value);
+
+    return (
+        <div ref={containerRef} className={`relative ${className}`}>
+            <div
+                onClick={() => !disabled && setIsOpen(!isOpen)}
+                className={`
+                    w-full flex items-center justify-between gap-2
+                    rounded-xl border-2 bg-gray-50 px-4 py-3 
+                    font-medium text-gray-900 transition cursor-pointer
+                    ${error ? 'border-red-500 bg-red-50' : 'border-gray-200 hover:border-gray-300'}
+                    ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+                `}
+            >
+                <div className="flex items-center gap-2 flex-1">
+                    <Calendar className="h-5 w-5 text-gray-400" />
+                    <span className={displayValue ? 'text-gray-900' : 'text-gray-400'}>
+                        {displayValue || placeholder}
+                    </span>
+                </div>
+                {displayValue && !disabled && (
+                    <button
+                        type="button"
+                        onClick={handleClear}
+                        className="p-1 hover:bg-gray-200 rounded-lg transition"
+                    >
+                        <X className="h-4 w-4 text-gray-500" />
+                    </button>
+                )}
+            </div>
+
+            {isOpen && (
+                <div className="absolute z-50 mt-2 w-full min-w-[320px] bg-white rounded-xl shadow-2xl border border-gray-200 p-4">
+                    <div className="flex items-center justify-between mb-4">
+                        <button
+                            type="button"
+                            onClick={prevMonth}
+                            className="p-2 hover:bg-gray-100 rounded-lg transition"
+                        >
+                            <ChevronLeft className="h-5 w-5 text-gray-600" />
+                        </button>
+                        <div className="text-center font-bold text-gray-800">
+                            {monthNames[viewDate.getMonth()]} {viewDate.getFullYear()}
+                        </div>
+                        <button
+                            type="button"
+                            onClick={nextMonth}
+                            className="p-2 hover:bg-gray-100 rounded-lg transition"
+                        >
+                            <ChevronRight className="h-5 w-5 text-gray-600" />
+                        </button>
+                    </div>
+
+                    <div className="grid grid-cols-7 gap-1 mb-2">
+                        {['D', 'L', 'M', 'M', 'J', 'V', 'S'].map((day, i) => (
+                            <div key={i} className="text-center text-xs font-bold text-gray-500 p-2">
+                                {day}
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="grid grid-cols-7 gap-1">
+                        {renderCalendar()}
+                    </div>
+
+                    <div className="mt-4 pt-3 border-t border-gray-100 flex items-center justify-between bg-gray-50 p-2 rounded-lg">
+                        <div className="flex items-center gap-2 text-gray-700 font-medium">
+                            <Clock className="h-4 w-4 text-gray-400" />
+                            <span className="text-sm">Hora:</span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                            <input
+                                type="number"
+                                min="0" max="23"
+                                value={String(viewDate.getHours()).padStart(2, '0')}
+                                onChange={(e) => handleTimeChange('hours', e.target.value)}
+                                className="w-12 p-1 text-center bg-white border border-gray-300 rounded outline-none focus:border-green-500 text-sm"
+                            />
+                            <span className="font-bold text-gray-500">:</span>
+                            <input
+                                type="number"
+                                min="0" max="59"
+                                value={String(viewDate.getMinutes()).padStart(2, '0')}
+                                onChange={(e) => handleTimeChange('minutes', e.target.value)}
+                                className="w-12 p-1 text-center bg-white border border-gray-300 rounded outline-none focus:border-green-500 text-sm"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="mt-4 pt-3 border-t border-gray-100 flex justify-between items-center">
+                        <button
+                            type="button"
+                            onClick={() => {
+                                const today = new Date();
+                                onChange(formatForBackend(today));
+                                setIsOpen(false);
+                            }}
+                            className="px-3 py-1.5 text-sm font-medium text-blue-600 hover:bg-blue-50 rounded-lg transition"
+                        >
+                            Ahora
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setIsOpen(false)}
+                            className="px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 rounded-lg transition"
+                        >
+                            OK
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/movimientos/create.tsx
+++ b/resources/js/pages/movimientos/create.tsx
@@ -5,6 +5,7 @@ import { FormEventHandler } from 'react';
 import { Concepto, MedioDePago, MovimientoFormData } from '@/types/movimiento';
 import DashboardLayout from '@/layouts/DashboardLayout';
 import DeleteButton from '@/components/botones/boton-eliminar';
+import DateTimePicker from '@/components/ui/DateTimePicker';
 
 interface Props {
     conceptos: Concepto[];
@@ -40,7 +41,9 @@ export default function Create({ conceptos, mediosDePago, tipo, label }: Props) 
         const year = now.getFullYear();
         const month = String(now.getMonth() + 1).padStart(2, '0');
         const day = String(now.getDate()).padStart(2, '0');
-        return `${year}-${month}-${day}`;
+        const hours = String(now.getHours()).padStart(2, '0');
+        const minutes = String(now.getMinutes()).padStart(2, '0');
+        return `${year}-${month}-${day} ${hours}:${minutes}`;
     };
 
     const { data, setData, post, processing, errors } = useForm<MovimientoFormData>({
@@ -91,13 +94,10 @@ export default function Create({ conceptos, mediosDePago, tipo, label }: Props) 
                             <label htmlFor="fecha" className="block text-sm font-semibold text-gray-800 mb-2">
                                 Fecha *
                             </label>
-                            <input
-                                id="fecha"
-                                type="date"
+                            <DateTimePicker
                                 value={data.fecha}
-                                onChange={(e) => setData('fecha', e.target.value)}
-                                className={`w-full px-4 py-3 bg-gray-50 border-2 rounded-xl focus:ring-2 ${current.ring500} ${current.border500} focus:bg-white outline-none transition text-gray-900 font-medium ${errors.fecha ? 'border-red-500 bg-red-50' : 'border-gray-200 hover:border-gray-300'
-                                    }`}
+                                onChange={(val) => setData('fecha', val)}
+                                error={!!errors.fecha}
                             />
                             {errors.fecha && (
                                 <p className={`mt-2 text-sm text-red-600 flex items-center gap-1`}>

--- a/resources/js/pages/movimientos/edit.tsx
+++ b/resources/js/pages/movimientos/edit.tsx
@@ -5,6 +5,7 @@ import { Concepto, MedioDePago, Movimiento } from '@/types/movimiento';
 import DeleteButton from '@/components/botones/boton-eliminar';
 import { View } from 'lucide-react';
 import ViewButton from '@/components/botones/boton-ver';
+import DateTimePicker from '@/components/ui/DateTimePicker';
 
 interface Props {
     movimiento: Movimiento;
@@ -18,7 +19,7 @@ export default function Edit({ movimiento, conceptos, mediosDePago, tipo, label 
     const tipoPlural = tipo.endsWith("s") ? tipo : `${tipo}s`;
 
     const { data, setData, processing, errors, post } = useForm({
-        fecha: movimiento.fecha.split("T")[0],
+        fecha: movimiento.fecha ? String(movimiento.fecha).replace('T', ' ').substring(0, 16) : '',
         monto: movimiento.monto,
         concepto_id: movimiento.concepto_id,
         medio_de_pago_id: movimiento.medio_de_pago_id,
@@ -73,12 +74,10 @@ export default function Edit({ movimiento, conceptos, mediosDePago, tipo, label 
                             <label className="block text-sm font-semibold text-gray-800 mb-2">
                                 Fecha *
                             </label>
-                            <input
-                                type="date"
+                            <DateTimePicker
                                 value={data.fecha}
-                                onChange={(e) => setData("fecha", e.target.value)}
-                                className={`w-full px-4 py-3 bg-gray-50 border-2 rounded-xl outline-none text-gray-900 font-medium transition ${errors.fecha ? "border-red-500 bg-red-50" : "border-gray-200 hover:border-gray-300"
-                                    }`}
+                                onChange={(val) => setData("fecha", val)}
+                                error={!!errors.fecha}
                             />
                             {errors.fecha && <p className="mt-2 text-sm text-red-600">{errors.fecha}</p>}
                         </div>

--- a/resources/js/pages/movimientos/index.tsx
+++ b/resources/js/pages/movimientos/index.tsx
@@ -5,7 +5,7 @@ import { Movimiento } from '@/types/movimiento';
 import DashboardLayout from '@/layouts/DashboardLayout';
 import EditButton from '@/components/botones/boton-editar';
 import ViewButton from '@/components/botones/boton-ver';
-import { formatDateToArgentina } from '@/utils/dateFormat';
+import { formatDateTimeToArgentina } from '@/utils/dateFormat';
 import { Lock } from 'lucide-react';
 
 interface Props {
@@ -102,7 +102,7 @@ export default function Index({ movimientos, tipo, label }: Props) {
                                         return (
                                             <tr key={movimiento.id} className="hover:bg-gray-50 transition">
                                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                                    {formatDateToArgentina(movimiento.fecha)}
+                                                    {formatDateTimeToArgentina(movimiento.fecha)}
                                                 </td>
                                                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                                                     {movimiento.concepto?.nombre || '-'}

--- a/resources/js/pages/movimientos/show.tsx
+++ b/resources/js/pages/movimientos/show.tsx
@@ -3,7 +3,7 @@ import DashboardLayout from '@/layouts/DashboardLayout';
 import { Movimiento } from '@/types/movimiento';
 import ViewButton from '@/components/botones/boton-ver';
 import { FileText } from 'lucide-react';
-import { formatDateToArgentina } from '@/utils/dateFormat';
+import { formatDateTimeToArgentina } from '@/utils/dateFormat';
 
 interface Props {
     movimiento: Movimiento;
@@ -40,7 +40,7 @@ console.log('Movimiento completo:', movimiento);
                     <div>
                         <p className="text-sm text-gray-600 font-semibold mb-2">Fecha</p>
                         <p className="text-lg font-bold text-gray-900">
-                            {formatDateToArgentina(movimiento.fecha)}
+                            {formatDateTimeToArgentina(movimiento.fecha)}
                         </p>
                     </div>
 

--- a/resources/js/pages/ordenes/createOrdenes.tsx
+++ b/resources/js/pages/ordenes/createOrdenes.tsx
@@ -37,7 +37,6 @@ type FormData = {
     observacion: string;
     fecha: string;
     detalles: Detalle[];
-    numero_orden_manual: boolean;
 };
 
 type Props = {
@@ -49,12 +48,6 @@ type Props = {
 };
 
 export default function CreateOrdenes({ titulares, estados, mediosDePago, articulos = [], companiasSeguros = [] }: Props) {
-    const generarNumeroOrden = (tipo: TipoDocumento) => {
-        const prefix = tipo === 'OT' ? 'OT' : 'FC';
-        const suffix = Date.now().toString().slice(-6);
-        return `${prefix}-${suffix}`;
-    };
-
     const detalleInicial: Detalle = {
         articulo_id: null,
         descripcion: '',
@@ -78,7 +71,6 @@ export default function CreateOrdenes({ titulares, estados, mediosDePago, articu
         pagos: [],
         observacion: '',
         fecha: '',
-        numero_orden_manual: false,
         detalles: [detalleInicial],
     };
 
@@ -112,20 +104,13 @@ export default function CreateOrdenes({ titulares, estados, mediosDePago, articu
         setData((prev: FormData) => ({
             ...prev,
             fecha: prev.fecha || hoy,
-            numero_orden: prev.numero_orden || generarNumeroOrden(prev.tipo_documento),
         }));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {
-        setData((prev: FormData) => {
-            if (prev.numero_orden_manual) return prev;
-            return {
-                ...prev,
-                numero_orden: generarNumeroOrden(prev.tipo_documento),
-            };
-        });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+        // El número correlativo se asigna en el backend automáticamente basándose en 'tipo_documento'.
+        // Ya no generamos en el frontend para evitar números saltados o sucios.
     }, [data.tipo_documento]);
 
     const vehiculosDelTitular = titulares.find((t: any) => t.id === data.titular_id)?.vehiculos || [];
@@ -279,22 +264,13 @@ export default function CreateOrdenes({ titulares, estados, mediosDePago, articu
                                 </div>
 
                                 <div>
-                                    <label className="mb-2 block text-sm font-semibold text-gray-800">Número de orden *</label>
+                                    <label className="mb-2 block text-sm font-semibold text-gray-800">Número de orden</label>
                                     <input
                                         type="text"
-                                        value={data.numero_orden}
-                                        onChange={(e) => {
-                                            setData((prev: FormData) => ({
-                                                ...prev,
-                                                numero_orden: e.target.value,
-                                                numero_orden_manual: true,
-                                            }));
-                                        }}
-                                        className={`w-full rounded-xl border-2 bg-gray-50 px-4 py-3 font-medium text-gray-900 transition outline-none ${(errors as any).numero_orden ? 'border-red-500 bg-red-50' : 'border-gray-200 hover:border-gray-300'
-                                            }`}
-                                        placeholder="OT-000000 / FC-000000"
+                                        disabled
+                                        value="(Se generará automáticamente)"
+                                        className="w-full rounded-xl border-2 bg-gray-100 text-gray-500 px-4 py-3 font-medium cursor-not-allowed outline-none border-gray-200"
                                     />
-                                    {(errors as any).numero_orden && <p className="mt-2 text-sm text-red-600">{(errors as any).numero_orden}</p>}
                                 </div>
 
                                 <div className="flex items-center gap-3 pt-7">

--- a/resources/js/pages/ordenes/createOrdenes.tsx
+++ b/resources/js/pages/ordenes/createOrdenes.tsx
@@ -9,7 +9,8 @@ import VehiculoSection, { VehiculoSectionRef } from '@/components/ui/VehiculoSec
 import DashboardLayout from '@/layouts/DashboardLayout';
 import PagosSection from '@/components/ui/PagosSection';
 import DatePicker from '@/components/ui/DataPicker';
-import { getArgentinaToday } from '@/utils/dateFormat';
+import DateTimePicker from '@/components/ui/DateTimePicker';
+import { getArgentinaNow } from '@/utils/dateFormat';
 
 type TipoDocumento = 'OT' | 'FC';
 
@@ -106,7 +107,7 @@ export default function CreateOrdenes({ titulares, estados, mediosDePago, articu
 
     // Defaults iniciales con fecha Argentina
     useEffect(() => {
-        const hoy = getArgentinaToday(); // Usa UTC-3
+        const hoy = getArgentinaNow(); // Usa UTC-3
 
         setData((prev: FormData) => ({
             ...prev,
@@ -315,7 +316,7 @@ export default function CreateOrdenes({ titulares, estados, mediosDePago, articu
                         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                             <div>
                                 <label className="mb-2 block text-sm font-semibold text-gray-800">Fecha *</label>
-                                <DatePicker
+                                <DateTimePicker
                                     value={data.fecha}
                                     onChange={(date: string) => setField('fecha', date)}
                                     error={!!allErrors.fecha}
@@ -326,7 +327,7 @@ export default function CreateOrdenes({ titulares, estados, mediosDePago, articu
 
                             <div>
                                 <label className="mb-2 block text-sm font-semibold text-gray-800">Fecha de entrega estimada *</label>
-                                <DatePicker
+                                <DateTimePicker
                                     value={data.fecha_entrega_estimada}
                                     onChange={(date: string) => setField('fecha_entrega_estimada', date)}
                                     minDate={data.fecha || undefined}

--- a/resources/js/pages/ordenes/edit.tsx
+++ b/resources/js/pages/ordenes/edit.tsx
@@ -9,7 +9,8 @@ import VehiculoSection, { VehiculoSectionRef } from "@/components/ui/VehiculoSec
 import DetallesSection, { Detalle as DetalleUI, ArticuloDTO } from "@/components/ui/DetallesSection";
 import EstadoSection from "@/components/ui/EstadoSection";
 import PagosSection from '@/components/ui/PagosSection';
-import { getArgentinaToday } from '@/utils/dateFormat';
+import { getArgentinaToday, getArgentinaNow } from '@/utils/dateFormat';
+import DateTimePicker from '@/components/ui/DateTimePicker';
 
 type Estado = { id: number; nombre: string };
 type MedioDePago = { id: number; nombre: string };
@@ -99,9 +100,9 @@ export default function Edit({
 
   const initial: FormData = {
     estado_id: orden.estado_id ?? null,
-    fecha: orden.fecha ? String(orden.fecha).substring(0, 10) : "",
+    fecha: orden.fecha ? String(orden.fecha).replace('T', ' ').substring(0, 16) : "",
     fecha_entrega_estimada: orden.fecha_entrega_estimada
-      ? String(orden.fecha_entrega_estimada).substring(0, 10)
+      ? String(orden.fecha_entrega_estimada).replace('T', ' ').substring(0, 16)
       : "",
     observacion: orden.observacion ?? "",
     con_factura: orden.con_factura ? 1 : 0,
@@ -267,25 +268,21 @@ export default function Edit({
 
               <div>
                 <label className="mb-2 block text-sm font-semibold text-gray-800">Fecha *</label>
-                <input
-                  type="date"
+                <DateTimePicker
                   value={data.fecha}
-                  onChange={(e) => setData((prev: FormData) => ({ ...prev, fecha: e.target.value }))}
-                  className={`w-full rounded-xl border-2 bg-gray-50 px-4 py-3 font-medium text-gray-900 transition outline-none ${uiErrors.fecha ? "border-red-500 bg-red-50" : "border-gray-200 hover:border-gray-300"
-                    }`}
+                  onChange={(val) => setData((prev: FormData) => ({ ...prev, fecha: val }))}
+                  error={!!uiErrors.fecha}
                 />
                 {errors.fecha && <p className="mt-2 text-sm text-red-600">{errors.fecha}</p>}
               </div>
 
               <div>
                 <label className="mb-2 block text-sm font-semibold text-gray-800">Fecha de entrega estimada *</label>
-                <input
-                  type="date"
+                <DateTimePicker
                   value={data.fecha_entrega_estimada}
-                  min={data.fecha || undefined}
-                  onChange={(e) => setData((prev: FormData) => ({ ...prev, fecha_entrega_estimada: e.target.value }))}
-                  className={`w-full rounded-xl border-2 bg-gray-50 px-4 py-3 font-medium text-gray-900 transition outline-none ${uiErrors.fecha_entrega_estimada ? "border-red-500 bg-red-50" : "border-gray-200 hover:border-gray-300"
-                    }`}
+                  onChange={(val) => setData((prev: FormData) => ({ ...prev, fecha_entrega_estimada: val }))}
+                  minDate={data.fecha || undefined}
+                  error={!!uiErrors.fecha_entrega_estimada}
                 />
                 {errors.fecha_entrega_estimada && <p className="mt-2 text-sm text-red-600">{errors.fecha_entrega_estimada}</p>}
               </div>

--- a/resources/js/pages/ordenes/edit.tsx
+++ b/resources/js/pages/ordenes/edit.tsx
@@ -291,12 +291,10 @@ export default function Edit({
                 <label className="mb-2 block text-sm font-semibold text-gray-800">Número de orden</label>
                 <input
                   type="text"
+                  disabled
                   value={data.numero_orden}
-                  onChange={(e) => mergeForm({ numero_orden: e.target.value })}
-                  placeholder="OT-000000 / FC-000000"
-                  className="w-full rounded-xl border-2 bg-gray-50 px-4 py-3 font-medium text-gray-900 transition outline-none border-gray-200 hover:border-gray-300"
+                  className="w-full rounded-xl border-2 bg-gray-100 px-4 py-3 font-medium text-gray-500 cursor-not-allowed outline-none border-gray-200"
                 />
-                {errors.numero_orden && <p className="mt-2 text-sm text-red-600">{errors.numero_orden}</p>}
               </div>
             </div>
 

--- a/resources/js/pages/ordenes/index.tsx
+++ b/resources/js/pages/ordenes/index.tsx
@@ -4,7 +4,7 @@ import DashboardLayout from "@/layouts/DashboardLayout";
 import DeleteButton from "@/components/botones/boton-eliminar";
 import EditButton from "@/components/botones/boton-editar";
 import ViewButton from "@/components/botones/boton-ver";
-import { formatDateToArgentina } from "@/utils/dateFormat";
+import { formatDateTimeToArgentina } from "@/utils/dateFormat";
 import { CheckCircle, AlertCircle } from "lucide-react";
 
 type Vehiculo = {
@@ -400,7 +400,7 @@ export default function Index({ ordenes }: { ordenes: any }) {
                         className="hover:bg-gray-50 transition"
                       >
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {formatDateToArgentina(orden.fecha)}
+                          {formatDateTimeToArgentina(orden.fecha)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                           {orden.titular_vehiculo?.titular

--- a/resources/js/pages/ordenes/show.tsx
+++ b/resources/js/pages/ordenes/show.tsx
@@ -91,7 +91,7 @@ export default function Show({
               <h1 className="text-3xl font-bold text-gray-900">Orden de Trabajo #{orden.id}</h1>
               <div className="flex items-center gap-2 mt-1 text-gray-600">
                 <Calendar className="w-4 h-4" />
-                <span>{formatDateToArgentina(orden.fecha)}</span>
+                <span>{formatDateTimeToArgentina(orden.fecha)}</span>
                 <span className="mx-1">•</span>
                 <span className={`px-2.5 py-0.5 rounded-full text-xs font-semibold border ${orden.estado.nombre === 'Entregado' ? 'bg-green-100 text-green-700 border-green-200' :
                   orden.estado.nombre === 'Cancelado' ? 'bg-red-100 text-red-700 border-red-200' :
@@ -318,7 +318,7 @@ export default function Show({
                             <div className="flex flex-col items-center justify-center px-3 py-2 bg-white rounded-lg border border-gray-200 shadow-sm min-w-[80px]">
                               <Calendar className="w-4 h-4 text-slate-400 mb-1" />
                               <span className="text-xs font-medium text-slate-600">
-                                {formatDateToArgentina(pago.fecha)}
+                                {formatDateTimeToArgentina(pago.fecha)}
                               </span>
                             </div>
 

--- a/resources/js/utils/dateFormat.ts
+++ b/resources/js/utils/dateFormat.ts
@@ -17,6 +17,23 @@ export function getArgentinaToday(): string {
 }
 
 /**
+ * Obtiene la fecha y hora actual en Argentina (UTC-3)
+ * Retorna en formato yyyy-mm-dd hh:mm para inputs y valores por defecto
+ */
+export function getArgentinaNow(): string {
+  const now = new Date();
+  const argDate = new Date(now.toLocaleString('en-US', { timeZone: 'America/Argentina/Buenos_Aires' }));
+  
+  const year = argDate.getFullYear();
+  const month = String(argDate.getMonth() + 1).padStart(2, '0');
+  const day = String(argDate.getDate()).padStart(2, '0');
+  const hours = String(argDate.getHours()).padStart(2, '0');
+  const minutes = String(argDate.getMinutes()).padStart(2, '0');
+  
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+}
+
+/**
  * Convierte una fecha en formato yyyy-mm-dd a dd/mm/yyyy para mostrar
  * @param dateString - Fecha en formato yyyy-mm-dd o ISO
  * @returns Fecha en formato dd/mm/yyyy


### PR DESCRIPTION
# Descripción del PR

Este Pull Request unifica dos importantes funcionalidades relacionadas al manejo de Fechas y Autonumeración para generar mayor consistencia y control dentro del ecosistema de **Movimientos** y **Órdenes de Trabajo**.

## 📝 Resumen de Cambios

### 1. Soporte de Horas y Minutos en Fechas 🕒
- **Base de Datos:** Migración para pasar las columnas de `fecha` (en `movimientos`) y `fecha_entrega_estimada` (en `orden_de_trabajo`) de tipo `DATE` a `DATETIME`.
- **Backend Modelos:** Se castearon activamente dichos atributos como `'datetime'` en ambos Modelos para asegurar que Eloquent procese y exponga correctamente los timestamps.
- **Frontend (UI / UX):** 
  - Se creó un nuevo componente reutilizable `<DateTimePicker>` que expande nuestro `<DatePicker>` original y añade soporte para deslizar y seleccionar horas/minutos manteniendo el mismo estándar de diseño de nuestra UI.
  - Se reemplazaron todas las variables de entrada de fecha en las vistas `create` y `edit` (tanto de O.T. como Movimientos) para usar el nuevo componente.
  - Se incorporó soporte visual llamando a `formatDateTimeToArgentina` (`DD/MM/YYYY HH:mm`) en todas las tablas (`index`) y menús de detalle (`show`).
  - Añadida la función de soporte `getArgentinaNow()` para pre-cargar la hora actual exacta (-3 UTC) del sistema cliente.

### 2. Numeración Correlativa Automatizada en O.T. 🔢
Se abandonó el formato de número aleatorio basado en el Timestamp y se migró a un estricto conteo ordenado (`[Prefijo]-000001`):
- **Lógica Backend:** El controlador `OrdenDeTrabajoController` fue modificado de modo que, independientemente de lo que mande el frontend, este verifica si la O.T. tiene factura (`FC-`) o no (`OT-`), busca de forma segura la última fila guardada para ese prefijo ordenándola por su valor numérico, y reserva el consecutivo rellenado con 6 dígitos.
- **Flujo de Trabajo:** Un número sólo se recalcula en `Update` si el cliente decide alterar retroactivamente el estado fiscal ("con factura" vs "sin factura") de una orden.
- **Frontend Segurizado:** Se bloqueó completamente (`disabled`) el input de "Número de O.T." en las interfaces visuales para imposibilitar una suplantación manual por parte de los empleados. Las vistas en creación ahora explican que este campo asume un valor de backend automático.

## ✅ Checklist
- [x] Migraciones ejecutadas sin conflictos
- [x] Pruebas manuales de captura de hora funcionales
- [x] Consecución lógica de numeraciones probadas
- [x] Sin regressions de Interfaz gráfica (Responsive Check)
