### PR TITLE
Feature vista taller

### DIFF
--- a/app/Http/Controllers/OrdenDeTrabajoController.php
+++ b/app/Http/Controllers/OrdenDeTrabajoController.php
@@ -400,26 +400,54 @@ class OrdenDeTrabajoController extends Controller
         ]);
     }*/
 
-    public function pendientes()
-{
-    $ots = OrdenDeTrabajo::with([
-            'estado',
-            'titularVehiculo.titular',
-            'titularVehiculo.vehiculo'
-        ])
-        ->whereIn('estado_id', Estado::idsParaTaller())
-        ->get();
+    public function pendientes(Request $request)
+    {
+        $ots = OrdenDeTrabajo::with([
+                'estado',
+                'titularVehiculo.titular',
+                'titularVehiculo.vehiculo.marca',
+                'titularVehiculo.vehiculo.modelo',
+            ])
+            ->whereIn('estado_id', Estado::idsParaTaller())
+            ->when($request->filled('q'), function ($query) use ($request) {
+                $q = $request->q;
+                $query->where(function ($sub) use ($q) {
+                    $sub->where('orden_de_trabajo.id', 'like', "%{$q}%")
+                        ->orWhereHas('titularVehiculo.titular', function ($q2) use ($q) {
+                            $q2->where('nombre', 'like', "%{$q}%")
+                                ->orWhere('apellido', 'like', "%{$q}%");
+                        })
+                        ->orWhereHas('titularVehiculo.vehiculo', function ($q2) use ($q) {
+                            $q2->where('patente', 'like', "%{$q}%");
+                        });
+                });
+            })
+            ->when(
+                $request->filled('estado_id'),
+                fn($q) => $q->where('estado_id', $request->estado_id)
+            )
+            ->when(
+                $request->filled('date_from'),
+                fn($q) => $q->whereDate('fecha', '>=', $request->date_from)
+            )
+            ->when(
+                $request->filled('date_to'),
+                fn($q) => $q->whereDate('fecha', '<=', $request->date_to)
+            )
+            ->orderByDesc('orden_de_trabajo.id')
+            ->get();
 
-    $estados = Estado::select('id', 'nombre')
-        ->whereIn('id', Estado::idsPermitidosCambioTaller())
-        ->orderBy('id')
-        ->get();
+        $estados = Estado::select('id', 'nombre')
+            ->whereIn('id', Estado::idsPermitidosCambioTaller())
+            ->orderBy('id')
+            ->get();
 
-    return Inertia::render('taller/ordenes', [
-        'ots' => $ots,
-        'estados' => $estados, // 👈 ESTO
-    ]);
-}
+        return Inertia::render('taller/ordenes', [
+            'ots' => $ots,
+            'estados' => $estados,
+            'filters' => $request->only(['q', 'estado_id', 'date_from', 'date_to']),
+        ]);
+    }
 
     public function cambiarEstadoTaller(Request $request, OrdenDeTrabajo $orden)
     {

--- a/app/Models/Estado.php
+++ b/app/Models/Estado.php
@@ -10,13 +10,15 @@ class Estado extends Model
 
     protected $fillable = ['nombre'];
 
-    public const INICIADO = 1;
-    public const PENDIENTE = 2;
-    public const COMPLETADA = 3;
+    public const ANULADA = 1;
+    public const INICIADO = 2;
+    public const EN_TALLER = 3;
+    public const COMPLETADA_TALLER = 4;
+    public const FINALIZADA = 5;
     public const ESTADOS_TALLER = [
         self::INICIADO,
-        self::PENDIENTE,
-        self::COMPLETADA,
+        self::EN_TALLER,
+        self::COMPLETADA_TALLER,
     ];
     public const ESTADOS_CAMBIO_TALLER = self::ESTADOS_TALLER;
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,7 +18,7 @@ class DatabaseSeeder extends Seeder
             CompaniasSegurosSeeder::class,
             ConceptosSeeder::class,
             MarcasModelosSeeder::class,
-            MetricsDemoSeeder::class,
+            // MetricsDemoSeeder::class,
         ]);
     }
 }

--- a/resources/js/pages/ordenes/index.tsx
+++ b/resources/js/pages/ordenes/index.tsx
@@ -428,10 +428,18 @@ export default function Index({ ordenes }: { ordenes: any }) {
                             : "Sin vehículo"}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
-                          <span className={`px-2 py-1 rounded text-white text-xs ${orden.estado?.nombre === 'Anulada' ? 'bg-red-500' :
-                            orden.estado?.nombre === 'Finalizada' ? 'bg-green-500' :
-                              'bg-blue-500'
-                            }`}>
+                          <span className={`px-2 py-1 rounded text-white text-xs font-semibold ${
+                            (() => {
+                              switch (orden.estado?.nombre) {
+                                case 'Anulada': return 'bg-red-500';
+                                case 'Iniciado': return 'bg-amber-500';
+                                case 'En taller': return 'bg-blue-500';
+                                case 'Completada por taller': return 'bg-teal-500';
+                                case 'Finalizada': return 'bg-green-500';
+                                default: return 'bg-gray-500';
+                              }
+                            })()
+                          }`}>
                             {orden.estado?.nombre ?? "-"}
                           </span>
                         </td>

--- a/resources/js/pages/taller/ordenes.tsx
+++ b/resources/js/pages/taller/ordenes.tsx
@@ -42,23 +42,21 @@ interface Props {
     filters?: Filters;
 }
 
-// Colores bien diferenciados por estado
+// Colores semánticos del flujo de taller
 const estadoBadge: Record<string, { pill: string }> = {
-    Iniciado:    { pill: 'bg-blue-500 text-white' },
-    'En taller': { pill: 'bg-orange-500 text-white' },
-    Pendiente:   { pill: 'bg-yellow-500 text-white' },
-    Completada:  { pill: 'bg-green-500 text-white' },
-    Finalizada:  { pill: 'bg-green-500 text-white' },
-    Anulada:     { pill: 'bg-red-500 text-white' },
+    Iniciado:                { pill: 'bg-amber-500 text-white' },
+    'En taller':             { pill: 'bg-blue-500 text-white' },
+    'Completada por taller': { pill: 'bg-green-500 text-white' },
+    Finalizada:              { pill: 'bg-green-500 text-white' },
+    Anulada:                 { pill: 'bg-red-500 text-white' },
 };
 
 const estadoFilterColors: Record<string, { active: string; inactive: string }> = {
-    Iniciado:    { active: 'bg-blue-600 text-white',   inactive: 'border border-blue-300 bg-blue-50 text-blue-700 hover:bg-blue-100' },
-    'En taller': { active: 'bg-orange-500 text-white', inactive: 'border border-orange-300 bg-orange-50 text-orange-700 hover:bg-orange-100' },
-    Pendiente:   { active: 'bg-yellow-500 text-white', inactive: 'border border-yellow-300 bg-yellow-50 text-yellow-700 hover:bg-yellow-100' },
-    Completada:  { active: 'bg-green-600 text-white',  inactive: 'border border-green-300 bg-green-50 text-green-700 hover:bg-green-100' },
-    Finalizada:  { active: 'bg-green-600 text-white',  inactive: 'border border-green-300 bg-green-50 text-green-700 hover:bg-green-100' },
-    Anulada:     { active: 'bg-red-600 text-white',    inactive: 'border border-red-300 bg-red-50 text-red-700 hover:bg-red-100' },
+    Iniciado:                { active: 'bg-amber-500 text-white',  inactive: 'border border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100' },
+    'En taller':             { active: 'bg-blue-600 text-white',   inactive: 'border border-blue-300 bg-blue-50 text-blue-700 hover:bg-blue-100' },
+    'Completada por taller': { active: 'bg-green-600 text-white',  inactive: 'border border-green-300 bg-green-50 text-green-700 hover:bg-green-100' },
+    Finalizada:              { active: 'bg-green-600 text-white',  inactive: 'border border-green-300 bg-green-50 text-green-700 hover:bg-green-100' },
+    Anulada:                 { active: 'bg-red-600 text-white',    inactive: 'border border-red-300 bg-red-50 text-red-700 hover:bg-red-100' },
 };
 
 function getBadgePill(nombre: string) {

--- a/resources/js/pages/taller/ordenes.tsx
+++ b/resources/js/pages/taller/ordenes.tsx
@@ -1,7 +1,7 @@
 import DashboardLayout from '@/layouts/DashboardLayout';
 import { Head, Link, router } from '@inertiajs/react';
-import { ArrowRight, Calendar, Car, User } from 'lucide-react';
-import { useState } from 'react';
+import { ArrowRight, Car, RotateCcw, Search, User, Wrench, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 
 interface OT {
@@ -29,127 +29,443 @@ interface Estado {
     nombre: string;
 }
 
+interface Filters {
+    q?: string;
+    estado_id?: string | number;
+    date_from?: string;
+    date_to?: string;
+}
+
 interface Props {
     ots: OT[];
     estados: Estado[];
+    filters?: Filters;
 }
 
-export default function OrdenesTaller({ ots, estados }: Props) {
+// Colores bien diferenciados por estado
+const estadoBadge: Record<string, { pill: string }> = {
+    Iniciado:    { pill: 'bg-blue-500 text-white' },
+    'En taller': { pill: 'bg-orange-500 text-white' },
+    Pendiente:   { pill: 'bg-yellow-500 text-white' },
+    Completada:  { pill: 'bg-green-500 text-white' },
+    Finalizada:  { pill: 'bg-green-500 text-white' },
+    Anulada:     { pill: 'bg-red-500 text-white' },
+};
+
+const estadoFilterColors: Record<string, { active: string; inactive: string }> = {
+    Iniciado:    { active: 'bg-blue-600 text-white',   inactive: 'border border-blue-300 bg-blue-50 text-blue-700 hover:bg-blue-100' },
+    'En taller': { active: 'bg-orange-500 text-white', inactive: 'border border-orange-300 bg-orange-50 text-orange-700 hover:bg-orange-100' },
+    Pendiente:   { active: 'bg-yellow-500 text-white', inactive: 'border border-yellow-300 bg-yellow-50 text-yellow-700 hover:bg-yellow-100' },
+    Completada:  { active: 'bg-green-600 text-white',  inactive: 'border border-green-300 bg-green-50 text-green-700 hover:bg-green-100' },
+    Finalizada:  { active: 'bg-green-600 text-white',  inactive: 'border border-green-300 bg-green-50 text-green-700 hover:bg-green-100' },
+    Anulada:     { active: 'bg-red-600 text-white',    inactive: 'border border-red-300 bg-red-50 text-red-700 hover:bg-red-100' },
+};
+
+function getBadgePill(nombre: string) {
+    return (estadoBadge[nombre] ?? { pill: 'bg-gray-500 text-white' }).pill;
+}
+
+function getFilterStyle(nombre: string) {
+    return estadoFilterColors[nombre] ?? { active: 'bg-gray-700 text-white', inactive: 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-100' };
+}
+
+export default function OrdenesTaller({ ots, estados, filters: backendFilters }: Props) {
     const [open, setOpen] = useState(false);
     const [ordenSeleccionada, setOrdenSeleccionada] = useState<OT | null>(null);
     const [estadoId, setEstadoId] = useState<number | null>(null);
+
+    const [searchQ, setSearchQ] = useState(backendFilters?.q ?? '');
+    const [dateFrom, setDateFrom] = useState(backendFilters?.date_from ?? '');
+    const [dateTo, setDateTo] = useState(backendFilters?.date_to ?? '');
+    const activeEstadoId = backendFilters?.estado_id ? Number(backendFilters.estado_id) : null;
 
     const getNombre = (value?: { nombre: string } | string) => {
         if (!value) return '';
         return typeof value === 'string' ? value : value.nombre;
     };
 
+    const todayISO = useMemo(() => {
+        const d = new Date();
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    }, []);
+
+    const yesterdayISO = useMemo(() => {
+        const d = new Date(); d.setDate(d.getDate() - 1);
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    }, []);
+
+    const last7ISO = useMemo(() => {
+        const d = new Date(); d.setDate(d.getDate() - 6);
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    }, []);
+
+    function applyFilters(overrides?: Partial<Filters>) {
+        const payload: Record<string, any> = {
+            q: searchQ,
+            estado_id: activeEstadoId ?? '',
+            date_from: dateFrom,
+            date_to: dateTo,
+            ...overrides,
+        };
+
+        const cleaned: Record<string, any> = {};
+        Object.entries(payload).forEach(([k, v]) => {
+            if (v === null || v === undefined) return;
+            if (typeof v === 'string' && v.trim() === '') return;
+            cleaned[k] = v;
+        });
+
+        router.get('/taller/ots', cleaned, {
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        });
+    }
+
+    function toggleEstadoFilter(id: number) {
+        applyFilters({ estado_id: activeEstadoId === id ? '' : id });
+    }
+
+    function resetFilters() {
+        setSearchQ('');
+        setDateFrom('');
+        setDateTo('');
+        router.get('/taller/ots', {}, {
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        });
+    }
+
+    const hasActiveFilters = (backendFilters?.q ?? '') !== '' || activeEstadoId !== null || (backendFilters?.date_from ?? '') !== '' || (backendFilters?.date_to ?? '') !== '';
+
     return (
-        <DashboardLayout title="Órdenes de Trabajo Pendientes">
+        <DashboardLayout>
             <Head title="Órdenes de Trabajo - Taller" />
 
-            {ots.length === 0 ? (
-                <div className="rounded-2xl border border-gray-200 bg-white p-10 text-center shadow-sm">
-                    <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-purple-100">
-                        <Car className="h-8 w-8 text-purple-600" />
+            <div className="mx-auto max-w-7xl">
+                {/* Header */}
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-3xl font-bold text-gray-900">Órdenes de Trabajo</h1>
+                        <p className="mt-2 text-gray-600">
+                            Gestión de taller · {ots.length} {ots.length === 1 ? 'orden' : 'órdenes'}
+                        </p>
                     </div>
-                    <h2 className="mb-2 text-xl font-bold text-gray-800">No hay órdenes pendientes</h2>
-                    <p className="text-gray-500">Cuando ingresen nuevas órdenes de trabajo aparecerán acá.</p>
                 </div>
-            ) : (
-                <div className="grid grid-cols-1 gap-6">
-                    {ots.map((ot) => (
-                        <div
-                            key={ot.id}
-                            className="flex flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm md:flex-row md:items-center md:justify-between"
+
+                {/* Filtros */}
+                <div className="mb-6 rounded-2xl border border-gray-200 bg-white p-4 shadow-lg">
+                    {/* Fila 1: Búsqueda */}
+                    <div>
+                        <label className="mb-1 block text-xs font-medium text-gray-600">Buscar (OT / Patente / Titular)</label>
+                        <input
+                            value={searchQ}
+                            onChange={(e) => setSearchQ(e.target.value)}
+                            onKeyDown={(e) => { if (e.key === 'Enter') applyFilters(); }}
+                            placeholder="Ej: 12, EYZ529 o Gomez"
+                            className="w-full rounded-lg border border-gray-400 bg-white px-3 py-2 text-sm text-gray-700 placeholder:text-gray-500 focus:border-gray-500 focus:ring-gray-200"
+                        />
+                    </div>
+
+                    {/* Fila 2: Presets rápidos + Desde/Hasta + Aplicar/Limpiar */}
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => applyFilters({ date_from: todayISO, date_to: todayISO })}
+                            className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
                         >
-                            <div className="space-y-2">
-                                <div className="flex items-center gap-2">
-                                    <span className="text-sm font-semibold text-purple-600">OT #{ot.id}</span>
-                                    <span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-semibold text-yellow-700">
-                                        {ot.estado.nombre}
-                                    </span>
-                                </div>
+                            Hoy
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => applyFilters({ date_from: yesterdayISO, date_to: yesterdayISO })}
+                            className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                        >
+                            Ayer
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => applyFilters({ date_from: last7ISO, date_to: todayISO })}
+                            className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                        >
+                            Últimos 7 días
+                        </button>
 
-                                <div className="flex items-center gap-2 text-sm text-gray-600">
-                                    <Calendar className="h-4 w-4" />
-                                    {new Date(ot.fecha).toLocaleDateString('es-AR')}
-                                </div>
+                        <div className="mx-1 hidden h-6 w-px bg-gray-300 sm:block" />
 
-                                <div className="flex items-center gap-2 text-sm text-gray-700">
-                                    <User className="h-4 w-4" />
-                                    {ot.titular_vehiculo?.titular ? (
-                                        <>
-                                            {ot.titular_vehiculo.titular.nombre} {ot.titular_vehiculo.titular.apellido}
-                                        </>
-                                    ) : (
-                                        <span className="text-gray-400 italic">Sin titular</span>
-                                    )}
-                                </div>
+                        <div className="flex items-center gap-1.5">
+                            <span className="text-xs text-gray-500">Desde</span>
+                            <input
+                                type="date"
+                                value={dateFrom}
+                                onChange={(e) => setDateFrom(e.target.value)}
+                                className="rounded-lg border border-gray-400 bg-white px-2 py-2 text-sm text-gray-700 focus:border-gray-500 focus:ring-gray-200"
+                            />
+                        </div>
+                        <div className="flex items-center gap-1.5">
+                            <span className="text-xs text-gray-500">Hasta</span>
+                            <input
+                                type="date"
+                                value={dateTo}
+                                onChange={(e) => setDateTo(e.target.value)}
+                                className="rounded-lg border border-gray-400 bg-white px-2 py-2 text-sm text-gray-700 focus:border-gray-500 focus:ring-gray-200"
+                            />
+                        </div>
 
-                                <div className="flex items-center gap-2 text-sm text-gray-700">
-                                    <Car className="h-4 w-4" />
-                                    {ot.titular_vehiculo?.vehiculo ? (
-                                        <>
-                                            {getNombre(ot.titular_vehiculo.vehiculo.marca)} {getNombre(ot.titular_vehiculo.vehiculo.modelo)} ·{' '}
-                                            <span className="font-mono">{ot.titular_vehiculo.vehiculo.patente}</span>
-                                        </>
-                                    ) : (
-                                        <span className="text-gray-400 italic">Sin vehículo</span>
-                                    )}
-                                </div>
-                            </div>
+                        <div className="flex-1" />
 
-                            <div className="flex items-center justify-end gap-3">
-                                <Link
-                                    href={`/taller/ordenes/${ot.id}`}
-                                    className="inline-flex items-center gap-2 rounded-xl bg-purple-600 px-5 py-2 font-semibold text-white shadow-sm transition hover:bg-purple-700"
-                                >
-                                    Ver orden
-                                    <ArrowRight className="h-4 w-4" />
-                                </Link>
+                        <button
+                            type="button"
+                            onClick={() => applyFilters()}
+                            className="rounded-lg bg-gray-900 px-4 py-2 font-medium text-white transition hover:bg-black"
+                        >
+                            Aplicar
+                        </button>
+                        <button
+                            type="button"
+                            onClick={resetFilters}
+                            className="rounded-lg border border-gray-400 bg-white px-4 py-2 font-medium text-gray-700 transition hover:bg-gray-200"
+                        >
+                            Limpiar
+                        </button>
+                    </div>
 
+                    {/* Fila 3: Botones de estado */}
+                    <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-gray-100 pt-3">
+                        <span className="text-xs font-medium text-gray-500">Filtrar por estado:</span>
+                        {estados.map((estado) => {
+                            const isActive = activeEstadoId === estado.id;
+                            const style = getFilterStyle(estado.nombre);
+                            return (
                                 <button
-                                    onClick={() => {
-                                        setOrdenSeleccionada(ot);
-                                        setEstadoId(ot.estado.id);
-                                        setOpen(true);
-                                    }}
-                                    className="inline-flex items-center rounded-xl border border-gray-300 px-5 py-2 text-gray-700 transition hover:bg-gray-100"
+                                    key={estado.id}
+                                    onClick={() => toggleEstadoFilter(estado.id)}
+                                    className={`inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium transition ${
+                                        isActive ? style.active : style.inactive
+                                    }`}
                                 >
-                                    Cambiar estado
+                                    {estado.nombre}
+                                    {isActive && <X className="h-3.5 w-3.5 ml-0.5" />}
                                 </button>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* Contenido */}
+                {ots.length === 0 ? (
+                    <div className="rounded-2xl border border-gray-200 bg-white p-12 text-center shadow-lg">
+                        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-100">
+                            <Car className="h-8 w-8 text-gray-400" />
+                        </div>
+                        <p className="text-lg font-semibold text-gray-500 mb-2">No hay órdenes para mostrar</p>
+                        <p className="text-sm text-gray-400 mb-4">
+                            {hasActiveFilters
+                                ? 'Probá ajustando los filtros de búsqueda.'
+                                : 'Cuando ingresen nuevas órdenes de trabajo aparecerán acá.'}
+                        </p>
+                        {hasActiveFilters && (
+                            <button
+                                onClick={resetFilters}
+                                className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+                            >
+                                <RotateCcw className="h-3.5 w-3.5" />
+                                Limpiar filtros
+                            </button>
+                        )}
+                    </div>
+                ) : (
+                    <div className="rounded-2xl border border-gray-200 bg-white shadow-lg overflow-hidden">
+                        {/* Tabla Desktop */}
+                        <div className="hidden md:block overflow-x-auto">
+                            <table className="w-full">
+                                <thead className="bg-gray-50 border-b border-gray-200">
+                                    <tr>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">OT</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Titular</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Vehículo</th>
+                                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Estado</th>
+                                        <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-200">
+                                    {ots.map((ot) => (
+                                        <tr key={ot.id} className="hover:bg-gray-50 transition">
+                                            <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900">
+                                                #{ot.id}
+                                            </td>
+                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                {new Date(ot.fecha).toLocaleDateString('es-AR')}
+                                            </td>
+                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                {ot.titular_vehiculo?.titular
+                                                    ? `${ot.titular_vehiculo.titular.nombre} ${ot.titular_vehiculo.titular.apellido}`
+                                                    : <span className="text-gray-400 italic">Sin titular</span>}
+                                            </td>
+                                            <td className="px-6 py-4 whitespace-nowrap">
+                                                {ot.titular_vehiculo?.vehiculo ? (
+                                                    <div className="flex items-center gap-2">
+                                                        <span className="inline-block rounded bg-gray-800 px-2.5 py-1 font-mono text-sm font-bold text-white tracking-wider">
+                                                            {ot.titular_vehiculo.vehiculo.patente}
+                                                        </span>
+                                                        <span className="text-sm text-gray-500">
+                                                            {getNombre(ot.titular_vehiculo.vehiculo.marca)} {getNombre(ot.titular_vehiculo.vehiculo.modelo)}
+                                                        </span>
+                                                    </div>
+                                                ) : (
+                                                    <span className="text-sm text-gray-400 italic">Sin vehículo</span>
+                                                )}
+                                            </td>
+                                            <td className="px-6 py-4 whitespace-nowrap text-sm">
+                                                <span className={`px-2.5 py-1 rounded text-xs font-semibold ${getBadgePill(ot.estado.nombre)}`}>
+                                                    {ot.estado.nombre}
+                                                </span>
+                                            </td>
+                                            <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                                <div className="flex justify-end gap-2">
+                                                    <Link
+                                                        href={`/taller/ordenes/${ot.id}`}
+                                                        className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-3.5 py-1.5 text-xs font-semibold text-white transition hover:bg-blue-700"
+                                                    >
+                                                        Ver orden
+                                                        <ArrowRight className="h-3.5 w-3.5" />
+                                                    </Link>
+                                                    <button
+                                                        onClick={() => {
+                                                            setOrdenSeleccionada(ot);
+                                                            setEstadoId(ot.estado.id);
+                                                            setOpen(true);
+                                                        }}
+                                                        className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-3.5 py-1.5 text-xs font-semibold text-gray-700 transition hover:bg-gray-100"
+                                                    >
+                                                        Cambiar estado
+                                                    </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        {/* Cards Mobile */}
+                        <div className="md:hidden divide-y divide-gray-200">
+                            {ots.map((ot) => (
+                                <div key={ot.id} className="p-4 space-y-3">
+                                    <div className="flex items-center justify-between">
+                                        <div className="flex items-center gap-2">
+                                            <span className="text-sm font-bold text-gray-900">OT #{ot.id}</span>
+                                            <span className={`px-2 py-0.5 rounded text-xs font-semibold ${getBadgePill(ot.estado.nombre)}`}>
+                                                {ot.estado.nombre}
+                                            </span>
+                                        </div>
+                                        <span className="text-xs text-gray-500">
+                                            {new Date(ot.fecha).toLocaleDateString('es-AR')}
+                                        </span>
+                                    </div>
+
+                                    <div className="space-y-1.5">
+                                        <div className="flex items-center gap-2 text-sm text-gray-700">
+                                            <User className="h-4 w-4 text-gray-400 shrink-0" />
+                                            {ot.titular_vehiculo?.titular
+                                                ? `${ot.titular_vehiculo.titular.nombre} ${ot.titular_vehiculo.titular.apellido}`
+                                                : <span className="text-gray-400 italic">Sin titular</span>}
+                                        </div>
+                                        <div className="flex items-center gap-2 text-sm text-gray-600">
+                                            <Car className="h-4 w-4 text-gray-400 shrink-0" />
+                                            {ot.titular_vehiculo?.vehiculo ? (
+                                                <div className="flex items-center gap-2">
+                                                    <span className="inline-block rounded bg-gray-800 px-2 py-0.5 font-mono text-xs font-bold text-white tracking-wider">
+                                                        {ot.titular_vehiculo.vehiculo.patente}
+                                                    </span>
+                                                    <span className="text-xs text-gray-500">
+                                                        {getNombre(ot.titular_vehiculo.vehiculo.marca)} {getNombre(ot.titular_vehiculo.vehiculo.modelo)}
+                                                    </span>
+                                                </div>
+                                            ) : (
+                                                <span className="text-gray-400 italic">Sin vehículo</span>
+                                            )}
+                                        </div>
+                                    </div>
+
+                                    <div className="flex items-center gap-2 pt-1">
+                                        <Link
+                                            href={`/taller/ordenes/${ot.id}`}
+                                            className="flex-1 inline-flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-blue-700"
+                                        >
+                                            Ver orden
+                                            <ArrowRight className="h-3.5 w-3.5" />
+                                        </Link>
+                                        <button
+                                            onClick={() => {
+                                                setOrdenSeleccionada(ot);
+                                                setEstadoId(ot.estado.id);
+                                                setOpen(true);
+                                            }}
+                                            className="flex-1 inline-flex items-center justify-center rounded-lg border border-gray-300 bg-white px-3 py-2 text-xs font-semibold text-gray-700 transition hover:bg-gray-100"
+                                        >
+                                            Cambiar estado
+                                        </button>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+
+                        {/* Footer */}
+                        <div className="flex items-center justify-between border-t border-gray-200 bg-white px-6 py-4">
+                            <div className="text-sm text-gray-600">
+                                Mostrando <span className="font-medium text-gray-900">{ots.length}</span> {ots.length === 1 ? 'orden' : 'órdenes'}
                             </div>
                         </div>
-                    ))}
-                </div>
-            )}
+                    </div>
+                )}
+            </div>
 
+            {/* Modal Cambiar Estado */}
             {open && ordenSeleccionada && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-                    <div className="w-full max-w-md space-y-4 rounded-xl bg-white p-6 shadow-lg">
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setOpen(false)}>
+                    <div
+                        className="w-full max-w-md mx-4 rounded-xl bg-white p-6 shadow-lg"
+                        onClick={(e) => e.stopPropagation()}
+                    >
                         <h3 className="text-lg font-bold text-gray-900">Cambiar estado de OT #{ordenSeleccionada.id}</h3>
 
-                        <select
-                            value={estadoId ?? ''}
-                            onChange={(e) => setEstadoId(Number(e.target.value))}
-                            className="w-full rounded-lg border border-gray-300 p-2"
-                        >
-                            {estados.map((estado) => (
-                                <option key={estado.id} value={estado.id}>
-                                    {estado.nombre}
-                                </option>
-                            ))}
-                        </select>
+                        <div className="mt-4 space-y-2">
+                            {estados.map((estado) => {
+                                const isSelected = estadoId === estado.id;
+                                const pillColor = getBadgePill(estado.nombre);
+                                return (
+                                    <button
+                                        key={estado.id}
+                                        type="button"
+                                        onClick={() => setEstadoId(estado.id)}
+                                        className={`flex w-full items-center gap-3 rounded-lg border-2 px-4 py-3 text-left transition ${
+                                            isSelected
+                                                ? 'border-blue-500 bg-blue-50'
+                                                : 'border-gray-200 bg-white hover:bg-gray-50'
+                                        }`}
+                                    >
+                                        <span className={`px-2 py-0.5 rounded text-xs font-semibold ${pillColor}`}>
+                                            {estado.nombre}
+                                        </span>
+                                        {isSelected && (
+                                            <span className="ml-auto text-blue-600 font-semibold text-sm">✓ Seleccionado</span>
+                                        )}
+                                    </button>
+                                );
+                            })}
+                        </div>
 
-                        <div className="flex justify-end gap-3 pt-4">
+                        <div className="mt-6 flex justify-end gap-3">
                             <button
                                 onClick={() => {
                                     setOpen(false);
                                     setOrdenSeleccionada(null);
                                     setEstadoId(null);
                                 }}
-                                className="rounded-lg border px-4 py-2 text-gray-600 hover:bg-gray-100"
+                                className="rounded-lg border border-gray-400 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
                             >
                                 Cancelar
                             </button>
@@ -178,7 +494,7 @@ export default function OrdenesTaller({ ots, estados }: Props) {
                                         },
                                     );
                                 }}
-                                className="rounded-lg bg-purple-600 px-4 py-2 text-white hover:bg-purple-700"
+                                className="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white transition hover:bg-black"
                             >
                                 Guardar
                             </button>


### PR DESCRIPTION
# PR: Mejoras en la vista del rol Taller

## Resumen

Rediseño de la vista de Órdenes de Trabajo para el rol **Taller**. Se agregaron herramientas de búsqueda, filtrado por estado y fecha, se corrigió un bug que mostraba órdenes anuladas, y se unificó la paleta de colores de los badges de estado en toda la aplicación.

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| [ordenes.tsx (taller)](file:///c:/xampp/htdocs/proyecto-cristales/resources/js/pages/taller/ordenes.tsx) | Rediseño completo del frontend |
| [OrdenDeTrabajoController.php](file:///c:/xampp/htdocs/proyecto-cristales/app/Http/Controllers/OrdenDeTrabajoController.php) | Búsqueda, filtros y orden DESC en backend |
| [Estado.php](file:///c:/xampp/htdocs/proyecto-cristales/app/Models/Estado.php) | Fix de constantes (IDs correctos) |
| [index.tsx (ordenes admin)](file:///c:/xampp/htdocs/proyecto-cristales/resources/js/pages/ordenes/index.tsx) | Colores de badges unificados |
| [DatabaseSeeder.php](file:///c:/xampp/htdocs/proyecto-cristales/database/seeders/DatabaseSeeder.php) | Comentado MetricsDemoSeeder |

---

## Cambios detallados

### 1. Rediseño de la vista Taller (`taller/ordenes.tsx`)

- **Tabla profesional** en desktop con columnas: OT, Fecha, Titular, Vehículo, Estado, Acciones
- **Cards responsivas** en mobile
- **Patentes destacadas** con badge oscuro monospace (`bg-gray-800`)
- **Marca y modelo** del vehículo visibles
- **Ordenamiento descendente** por ID (las más nuevas primero)

### 2. Filtros completos

- **Búsqueda** por Nº de OT, patente, o nombre/apellido del titular
- **Filtro por estado**: botones toggle con colores semánticos por estado (no dropdowns)
- **Filtro por fecha**: inputs Desde/Hasta con presets rápidos (`Hoy`, `Ayer`, `Últimos 7 días`)
- **Botón Limpiar** que resetea todos los filtros

### 3. Bugfix: Órdenes anuladas visibles en Taller

> [!IMPORTANT]
> Las constantes del modelo `Estado` estaban mal mapeadas a la base de datos.

| Constante | Valor anterior (incorrecto) | Valor corregido |
|-----------|---------------------------|-----------------|
| `ANULADA` | *(no existía)* | `1` |
| `INICIADO` | `1` ← era Anulada en la BD | `2` |
| `EN_TALLER` | *(no existía)* | `3` |
| `COMPLETADA_TALLER` | *(no existía)* | `4` |
| `FINALIZADA` | *(no existía)* | `5` |

`ESTADOS_TALLER` pasó de `[1, 2, 3]` (incluía Anulada) a `[2, 3, 4]` (Iniciado, En taller, Completada por taller).

### 4. Colores de badges unificados (admin + taller)

| Estado | Color | Usado en |
|--------|-------|----------|
| Anulada | 🔴 Rojo (`bg-red-500`) | Admin |
| Iniciado | 🟡 Ámbar (`bg-amber-500`) | Ambos |
| En taller | 🔵 Azul (`bg-blue-500`) | Ambos |
| Completada por taller | 🩵 Teal (`bg-teal-500`) | Admin |
| Finalizada | 🟢 Verde (`bg-green-500`) | Admin |

### 5. Modal de cambio de estado

El dropdown fue reemplazado por **botones tipo card** seleccionables con:
- Color del badge correspondiente al estado
- Checkmark visual al seleccionar
- Borde azul destacando la selección
